### PR TITLE
Remove cancha selection from calendar and adjust availability

### DIFF
--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -72,7 +72,6 @@ const horaSelect  = document.getElementById('reservaHora');
   const entrenadorSelect  = form.querySelector('#entrenador');
   const responsableInput   = form.querySelector('#responsable');
   const canchasSelect     = form.querySelector('#canchas');
-  const canchaFilter = document.getElementById('canchaFilter');
   // Listener para cambio de tipo en el select del modal
   typeSelect.addEventListener('change', e => {
     switchFields(e.target.value);
@@ -223,7 +222,6 @@ const horaSelect  = document.getElementById('reservaHora');
       canchasSelect.value    = '';
 	  fechaInput.value = info.startStr.split('T')[0];
       // (opcional) deja cancha en valor actual
-      // canchaInput.value ya debería venir de tu HTML
 
       // dispara la recarga de slots
       cargarSlots();
@@ -329,7 +327,6 @@ form.action                          = '/reservas/' + ev.id;
 
     // 5) Volvemos a colocar los listeners
     fechaInput.addEventListener('change',   cargarSlots);
-    canchaInput.addEventListener('change',  cargarSlots);
 
     // 6) Abrimos el modal
     modal.show();
@@ -338,11 +335,7 @@ form.action                          = '/reservas/' + ev.id;
 
        events: {
         url: cfg.eventsUrl,   // p.ej. '/reservas.json'
-        method: 'GET',
-        extraParams: () => {
-          console.log('Enviando cancha_id:', canchaFilter.value);
-          return { cancha_id: canchaFilter.value };
-        }
+        method: 'GET'
       },
 	   // 2) Permite seleccionar rangos
     
@@ -359,12 +352,10 @@ form.action                          = '/reservas/' + ev.id;
 	   
     }),
 	
-	datesSet: info => {
+        datesSet: info => {
       // cada vez que cambias de día, recarga disponibilidad
       const date = info.startStr.split('T')[0];
-	  const canchaInput = document.getElementById('cancha');
-	   const canchaId = canchaInput.value || '1';
-      axios.get('/reserva/availability', { params: { date,  cancha_id: canchaId } })
+      axios.get('/reserva/availability', { params: { date } })
         .then(res => {
           const { minTime, maxTime } = res.data;
           calendar.setOption('slotMinTime', minTime);
@@ -389,8 +380,7 @@ form.action                          = '/reservas/' + ev.id;
 
   /* ---- 2)  COMMON data: extended props ---- */
   const estado = arg.event.extendedProps.status;      // Confirmada / Pendiente…
-  const cancha = arg.event.extendedProps.cancha;      // opcional, si la envías
-  const time   = arg.timeText;      
+  const time   = arg.timeText;
 
    
 
@@ -407,11 +397,9 @@ form.action                          = '/reservas/' + ev.id;
     const cont = document.createElement('div');
     cont.classList.add('d-flex', 'flex-column', 'gap-1');
 
-    // línea 1: cancha + título principal
+    // línea 1: título principal
     const fila1 = document.createElement('div');
-    fila1.innerHTML =
-      (cancha ? `<strong>${cancha}</strong> — ` : '') +
-      `<span class="fw-bold">${lineas[0]}</span>`;
+    fila1.innerHTML = `<span class="fw-bold">${lineas[0]}</span>`;
     cont.appendChild(fila1);
 
     // líneas extra del título, si las hubiera
@@ -485,12 +473,6 @@ form.action                          = '/reservas/' + ev.id;
 
 
   calendar.render();
-  canchaFilter.addEventListener('change', () => {
-    // Opcional: limpia la capa visual
-    calendar.removeAllEvents();
-    // Y vuelve a cargar con el nuevo filtro
-    calendar.refetchEvents();
-  });
   
  
   form.addEventListener('submit', () => {
@@ -543,22 +525,20 @@ form.action                          = '/reservas/' + ev.id;
 
 
 const fechaInput  = document.getElementById('reservaFecha');
-const canchaInput = document.getElementById('cancha');
 const horaSelect  = document.getElementById('reservaHora');
 
 function cargarSlots() {
-  const date     = fechaInput.value;
-  const canchaId = canchaInput.value || '1';
+  const date = fechaInput.value;
 
-  if (!date || !canchaId) {
+  if (!date) {
     horaSelect.innerHTML = '<option value="">-- Elige hora --</option>';
-    return  Promise.resolve();
+    return Promise.resolve();
   }
 
- return axios.get('/reserva/availability', {
-    params: { date, cancha_id: canchaId }
+  return axios.get('/reserva/availability', {
+    params: { date }
   })
- .then(res => {
+  .then(res => {
     horaSelect.innerHTML = '<option value="">-- Elige hora --</option>';
     res.data.slots.forEach(h => {
       // `h` ya viene como "HH:mm"
@@ -574,9 +554,6 @@ function cargarSlots() {
 // Cuando cambie la fecha..
 
 fechaInput.addEventListener('change', cargarSlots);
-
-// …o cuando cambie la cancha.
-canchaInput.addEventListener('change', cargarSlots);
 
 
 

--- a/resources/views/reservas/calendar.blade.php
+++ b/resources/views/reservas/calendar.blade.php
@@ -8,21 +8,9 @@
       <h5>Calendario de Clases y Reservas</h5>
     </div>
 
-    <div class="mb-4 px-4 py-3 d-flex justify-content-between align-items-center">
+    <div class="mb-4 px-4 py-3">
       <a href="{{ route('reservas.horario', ['date' => now()->toDateString()]) }}"
          class="btn btn-info">Ir a Día</a>
-
-      <div class="d-flex align-items-center">
-        <label for="canchaFilter" class="form-label me-2 mb-0">Filtrar cancha:</label>
-        <select id="canchaFilter"
-                class="form-select shadow-sm rounded-pill ps-4 pe-5 border-0"
-                style="min-width: 200px; background-color: #f8f9fa;">
-          <option value="">Todas</option>
-          @foreach($canchas as $cancha)
-            <option value="{{ $cancha->id }}">{{ $cancha->nombre }}</option>
-          @endforeach
-        </select>
-      </div>
     </div>
 
     <div class="wrapper-calendar" style="border-top:5px solid #D4A017;">


### PR DESCRIPTION
## Summary
- drop cancha filter from calendar view
- check availability only against user reservations
- stop sending cancha filters in calendar JS

## Testing
- `php -d detect_unicode=0 vendor/bin/phpunit` *(fails: Could not open input file: vendor/bin/phpunit)*
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68a53ac431a483249cbddba6cdbbe7b8