### PR TITLE
Add stylist color option and calendar filter

### DIFF
--- a/app/Http/Controllers/ReservaController.php
+++ b/app/Http/Controllers/ReservaController.php
@@ -98,9 +98,11 @@ class ReservaController extends Controller
     $query = Reserva::with(['cliente', 'entrenador']);
     if ($request->filled('cancha_id')) {
         $query->where('cancha_id', $request->cancha_id);
-		
     }
-	$query->where('estado', '<>', 'Cancelada');
+    if ($request->filled('entrenador_id')) {
+        $query->where('entrenador_id', $request->entrenador_id);
+    }
+    $query->where('estado', '<>', 'Cancelada');
     $reservas = $query->get();
 	
 	  
@@ -112,7 +114,7 @@ class ReservaController extends Controller
                           ->addMinutes($r->duracion)
                           ->toIso8601String();
 						  
-						  $rgba = 'rgba(96,66,245,0.35)';
+        $color = optional($r->entrenador)->color ?? '#6042F5';
 
         $base = [
             'id'              => $r->id,
@@ -121,19 +123,17 @@ class ReservaController extends Controller
             'type'            => $r->tipo,
             'status'          => $r->estado,
             'duration'        => $r->duracion,
-			
-            'title' =>  optional($r->cliente)->nombres . ' ' . optional($r->cliente)->apellidos,
-			'borderColor'     => str_replace('0.35', '1', $rgba), // mismo color, opaco
-            'textColor'       => '#121212', 
-            'backgroundColor' => $rgba,
-			 'extendedProps'   => [
-                'tipo'   => $r->tipo,              // reserva | torneo | clase
-                'estado' => $r->estado,            // confirmada | pendiente
-				
-				 
+            'title'           => optional($r->cliente)->nombres . ' ' . optional($r->cliente)->apellidos,
+            'borderColor'     => $color,
+            'textColor'       => '#121212',
+            'backgroundColor' => $color,
+            'extendedProps'   => [
+                'tipo'          => $r->tipo,              // reserva | torneo | clase
+                'estado'        => $r->estado,            // confirmada | pendiente
+                'entrenador_id' => $r->entrenador_id,
             ],
             'cancha_id'       => $r->cancha_id,
-			
+            'entrenador_id'   => $r->entrenador_id,
         ];
 
       

--- a/app/Http/Controllers/UsuarioController.php
+++ b/app/Http/Controllers/UsuarioController.php
@@ -40,6 +40,7 @@ class UsuarioController extends Controller
             'direccion'             => 'required|string|max:255',
             'whatsapp'              => 'required|string|max:30',
             'password'              => 'required|string|confirmed|min:8',
+            'color'                => 'nullable|string|max:7',
         ]);
 
         User::create([
@@ -54,6 +55,7 @@ class UsuarioController extends Controller
             'password'              => Hash::make($data['password']),
             'peluqueria_id'               => Auth::user()->peluqueria_id,
             'role'                  => 11,  // entranador
+            'color'                 => $data['color'] ?? null,
         ]);
 
         return redirect()
@@ -73,6 +75,7 @@ class UsuarioController extends Controller
             'direccion'             => 'required|string|max:255',
             'whatsapp'              => 'required|string|max:30',
             'password'              => 'required|string|confirmed|min:8',
+            'color'                => 'nullable|string|max:7',
         ]);
 
         User::create([
@@ -87,6 +90,7 @@ class UsuarioController extends Controller
             'password'              => Hash::make($data['password']),
             'peluqueria_id'               => Auth::user()->peluqueria_id,
             'role'                  => 18,  // administrador
+            'color'                 => $data['color'] ?? null,
         ]);
 
         return redirect()

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -37,6 +37,7 @@ class User extends Authenticatable
         'password',
         'peluqueria_id',
         'role',
+        'color',
     ];
 
     /**

--- a/database/migrations/tenant/2025_07_10_215719_add_color_to_usuarios_table.php
+++ b/database/migrations/tenant/2025_07_10_215719_add_color_to_usuarios_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('usuarios', function (Blueprint $table) {
+            $table->string('color', 7)->nullable()->after('role');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('usuarios', function (Blueprint $table) {
+            $table->dropColumn('color');
+        });
+    }
+};

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -48,6 +48,7 @@ document.addEventListener('DOMContentLoaded', () => {
   const modal      = new bootstrap.Modal(modalEl);
   const form       = modalEl.querySelector('form');
   form.setAttribute('method', 'POST');
+  const entrenadorFilter = document.querySelector(cfg.filterSelector);
 
   const methodIn      = form.querySelector('#reservationMethod');
   const typeSelect    = form.querySelector('#eventType');
@@ -140,11 +141,7 @@ const horaSelect  = document.getElementById('reservaHora');
 
   // Mostrar/ocultar campos según tipo
   function switchFields(type) {
-    if (type === 'Reserva') {
-      clientesField.classList.remove('d-none');
-      entrenadorField.classList.add('d-none');
-      responsableField.classList.add('d-none');
-    } else if (type === 'Clase') {
+    if (type === 'Reserva' || type === 'Clase') {
       clientesField.classList.remove('d-none');
       entrenadorField.classList.remove('d-none');
       responsableField.classList.add('d-none');
@@ -240,7 +237,7 @@ const horaSelect  = document.getElementById('reservaHora');
       methodIn.value                       = 'PUT';
 form.action                          = '/reservas/' + ev.id;
       form.method                          = 'POST';
-		 // 1) Rellenar el input de fecha (YYYY-MM-DD)
+                 // 1) Rellenar el input de fecha (YYYY-MM-DD)
   //    ev.start.toISOString() === "2025-06-12T14:30:00.000Z"
   fechaInput.value = ev.start.toISOString().split('T')[0];
  
@@ -249,6 +246,7 @@ form.action                          = '/reservas/' + ev.id;
 		
      // inicioInput.value                    = ev.start.toISOString().slice(0,16);
       durationSelect.value                 = props.duration;
+      entrenadorSelect.value              = props.entrenador_id || '';
 
         
       
@@ -277,9 +275,12 @@ form.action                          = '/reservas/' + ev.id;
   });
     },
 
-       events: {
+      events: {
         url: cfg.eventsUrl,   // p.ej. '/reservas.json'
-        method: 'GET'
+        method: 'GET',
+        extraParams: () => ({
+          entrenador_id: entrenadorFilter ? entrenadorFilter.value : ''
+        })
       },
 	   // 2) Permite seleccionar rangos
     
@@ -290,9 +291,9 @@ form.action                          = '/reservas/' + ev.id;
       start:           raw.start,
       end:             raw.end,
       backgroundColor: raw.backgroundColor,
-     // borderColor:     raw.color,
+      borderColor:     raw.borderColor,
       display:         'block',
-      extendedProps:   raw,   
+      extendedProps:   raw,
 	   
     }),
 	
@@ -417,6 +418,10 @@ form.action                          = '/reservas/' + ev.id;
 
 
   calendar.render();
+
+  if (entrenadorFilter) {
+    entrenadorFilter.addEventListener('change', () => calendar.refetchEvents());
+  }
   
  
   form.addEventListener('submit', () => {

--- a/resources/views/reservas/calendar.blade.php
+++ b/resources/views/reservas/calendar.blade.php
@@ -4,14 +4,22 @@
 @section('content')
 
   <div class="card">
-    <div class="card-header">
-      <h5>Calendario de Clases y Reservas</h5>
+    <div class="card-header d-flex flex-wrap justify-content-between align-items-center">
+      <h5 class="mb-0">Calendario de Clases y Reservas</h5>
+      <div class="mt-2 mt-sm-0">
+        <select id="entrenadorFilter" class="form-select">
+          <option value="">Todos los estilistas</option>
+          @foreach($entrenadores as $e)
+            <option value="{{ $e->id }}">{{ $e->nombre }}</option>
+          @endforeach
+        </select>
+      </div>
     </div>
 
-   
 
-    <div class="wrapper-calendar" style="border-top:5px solid #D4A017;">
-      <div id="calendar"></div>
+
+    <div class="wrapper-calendar w-100" style="border-top:5px solid #D4A017;">
+      <div id="calendar" class="w-100"></div>
     </div>
 
     @include('reservas.partials.reservation-modal')
@@ -32,7 +40,8 @@
       window.CalendarConfig = {
         selector: '#calendar',
         eventsUrl: '{{ route('reservas.events') }}',
-        modalSelector: '#reservationModal'
+        modalSelector: '#reservationModal',
+        filterSelector: '#entrenadorFilter'
       };
     });
   </script>

--- a/resources/views/users/partials/form-fields.blade.php
+++ b/resources/views/users/partials/form-fields.blade.php
@@ -98,6 +98,16 @@
 </div>
 
 
+{{-- Color --}}
+<div class="mb-3">
+  <label for="color" class="form-label">Color</label>
+  <input id="color"
+         name="color"
+         type="color"
+         class="form-control form-control-color"
+         value="{{ old('color', '#6042F5') }}">
+</div>
+
 {{-- Password --}}
 <div class="mb-3">
   <label for="password" class="form-label">Contraseña</label>


### PR DESCRIPTION
## Summary
- allow assigning a color to stylists
- color-code reservations and filter calendar by stylist
- support stylist selection in reservation modal and make calendar responsive

## Testing
- `npm run build`
- `./vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a65510a67483248463a6a9f1e009db