### PR TITLE
Add user edit and update actions

### DIFF
--- a/app/Http/Controllers/UsuarioController.php
+++ b/app/Http/Controllers/UsuarioController.php
@@ -104,14 +104,57 @@ class UsuarioController extends Controller
         return view('users.create_admin');
     }
 
-   
-	
-	public function index()
-{
-	$peluqueriaId=Auth::user()->peluqueria_id;
-	
-    $users = User::with('peluqueria') ->where('peluqueria_id', $peluqueriaId)->orderBy('nombre')->paginate(15);
-    return view('users.index', compact('users'));
-}
+    public function index()
+    {
+        $peluqueriaId = Auth::user()->peluqueria_id;
+
+        $users = User::with('peluqueria')
+            ->where('peluqueria_id', $peluqueriaId)
+            ->orderBy('nombre')
+            ->paginate(15);
+
+        return view('users.index', compact('users'));
+    }
+
+    public function edit(User $user)
+    {
+        return view('users.edit', compact('user'));
+    }
+
+    public function update(Request $request, User $user)
+    {
+        $data = $request->validate([
+            'nombre' => 'required|string|max:255',
+            'apellidos' => 'required|string|max:255',
+            'email' => 'required|email|unique:usuarios,email,' . $user->id,
+            'tipo_identificacion' => 'required|string|max:50',
+            'numero_identificacion' => 'required|string|max:50',
+            'direccion' => 'required|string|max:255',
+            'whatsapp' => 'required|string|max:30',
+            'password' => 'nullable|string|confirmed|min:8',
+            'color' => 'nullable|string|max:7',
+        ]);
+
+        $updateData = [
+            'nombre' => $data['nombre'],
+            'apellidos' => $data['apellidos'],
+            'email' => $data['email'],
+            'tipo_identificacion' => $data['tipo_identificacion'],
+            'numero_identificacion' => $data['numero_identificacion'],
+            'direccion' => $data['direccion'],
+            'whatsapp' => $data['whatsapp'],
+            'color' => $data['color'] ?? null,
+        ];
+
+        if (!empty($data['password'])) {
+            $updateData['password'] = Hash::make($data['password']);
+        }
+
+        $user->update($updateData);
+
+        return redirect()
+            ->route('users.index')
+            ->with('success', 'Usuario actualizado correctamente.');
+    }
 
 }

--- a/resources/views/users/edit.blade.php
+++ b/resources/views/users/edit.blade.php
@@ -1,0 +1,22 @@
+@extends('layouts.vertical', ['subtitle' => 'Editar Usuario'])
+
+@section('content')
+  <div class="container">
+    <h1>Editar Usuario</h1>
+
+    @if(session('success'))
+      <div class="alert alert-success">{{ session('success') }}</div>
+    @endif
+<div class="card card-body">
+    <form method="POST" action="{{ route('users.update', $user) }}">
+      @csrf
+      @method('PUT')
+
+      @include('users.partials.form-fields', ['user' => $user])
+
+      <button type="submit" class="btn btn-primary">Guardar Cambios</button>
+    </form>
+    </div>
+  </div>
+@endsection
+

--- a/resources/views/users/index.blade.php
+++ b/resources/views/users/index.blade.php
@@ -59,7 +59,7 @@
           </td>
           <td>{{ optional($user->peluqueria)->nombre ?? '—' }}</td>
           <td class="text-end">
-            <a href="{{ route('users.edit', $user->id) }}" class="btn btn-sm btn-outline-primary">
+            <a href="{{ route('users.edit', $user) }}" class="btn btn-sm btn-outline-primary">
               Editar
             </a>
             <form action="{{ route('users.destroy', $user->id) }}" method="POST" class="d-inline-block"

--- a/resources/views/users/partials/form-fields.blade.php
+++ b/resources/views/users/partials/form-fields.blade.php
@@ -5,7 +5,7 @@
          name="nombre"
          type="text"
          class="form-control @error('nombre') is-invalid @enderror"
-         value="{{ old('nombre') }}"
+         value="{{ old('nombre', $user->nombre ?? '') }}"
          required>
   @error('nombre') <div class="invalid-feedback">{{ $message }}</div> @enderror
 </div>
@@ -17,7 +17,7 @@
          name="apellidos"
          type="text"
          class="form-control @error('apellidos') is-invalid @enderror"
-         value="{{ old('apellidos') }}"
+         value="{{ old('apellidos', $user->apellidos ?? '') }}"
          required>
   @error('apellidos') <div class="invalid-feedback">{{ $message }}</div> @enderror
 </div>
@@ -29,7 +29,7 @@
          name="email"
          type="email"
          class="form-control @error('email') is-invalid @enderror"
-         value="{{ old('email') }}"
+         value="{{ old('email', $user->email ?? '') }}"
          required>
   @error('email') <div class="invalid-feedback">{{ $message }}</div> @enderror
 </div>
@@ -55,7 +55,7 @@
          name="tipo_identificacion"
          type="text"
          class="form-control @error('tipo_identificacion') is-invalid @enderror"
-         value="{{ old('tipo_identificacion') }}"
+         value="{{ old('tipo_identificacion', $user->tipo_identificacion ?? '') }}"
          required>
   @error('tipo_identificacion') <div class="invalid-feedback">{{ $message }}</div> @enderror
 </div>
@@ -67,7 +67,7 @@
          name="numero_identificacion"
          type="text"
          class="form-control @error('numero_identificacion') is-invalid @enderror"
-         value="{{ old('numero_identificacion') }}"
+         value="{{ old('numero_identificacion', $user->numero_identificacion ?? '') }}"
          required>
   @error('numero_identificacion') <div class="invalid-feedback">{{ $message }}</div> @enderror
 </div>
@@ -79,7 +79,7 @@
          name="direccion"
          type="text"
          class="form-control @error('direccion') is-invalid @enderror"
-         value="{{ old('direccion') }}"
+         value="{{ old('direccion', $user->direccion ?? '') }}"
          required>
   @error('direccion') <div class="invalid-feedback">{{ $message }}</div> @enderror
 </div>
@@ -91,7 +91,7 @@
          name="whatsapp"
          type="tel"
          class="form-control @error('whatsapp') is-invalid @enderror"
-         value="{{ old('whatsapp') }}"
+         value="{{ old('whatsapp', $user->whatsapp ?? '') }}"
          placeholder="+57 300 123 4567"
          required>
   @error('whatsapp') <div class="invalid-feedback">{{ $message }}</div> @enderror
@@ -105,7 +105,7 @@
          name="color"
          type="color"
          class="form-control form-control-color"
-         value="{{ old('color', '#6042F5') }}">
+         value="{{ old('color', $user->color ?? '#6042F5') }}">
 </div>
 
 {{-- Password --}}
@@ -115,7 +115,7 @@
          name="password"
          type="password"
          class="form-control @error('password') is-invalid @enderror"
-         required>
+         @if(!isset($user)) required @endif>
   @error('password') <div class="invalid-feedback">{{ $message }}</div> @enderror
 </div>
 
@@ -126,5 +126,5 @@
          name="password_confirmation"
          type="password"
          class="form-control"
-         required>
+         @if(!isset($user)) required @endif>
 </div>


### PR DESCRIPTION
## Summary
- implement `edit` action to render user edit form
- add `update` logic with validation, unique email rule and optional password update
- provide user edit view and update shared form fields for editing
- point edit button at correct route

## Testing
- `composer install` *(fails: GitHub token required to download symfony/polyfill-php80)*
- `php artisan test` *(fails: require(/workspace/AluresTech/vendor/autoload.php): No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68ae28ad734083248e26bdb1b969624d