### PR TITLE
Refine ventas view with pastel gold accents

### DIFF
--- a/resources/views/ventas/index.blade.php
+++ b/resources/views/ventas/index.blade.php
@@ -53,7 +53,7 @@
   {{-- Columna mayor: tarjeta de la orden --}}
   <div class="col-md-8">
     <div class="card mb-4 shadow-sm" >
-      <div class="card-header text-white" style="background: linear-gradient(to right, #0053BF, #6366F1);">
+      <div class="card-header" style="background-color: #f8e5a1; color: #6c4e09;">
         <i class="fa fa-file-invoice me-2"></i>
         Orden de Compra #{{ $ordenSeleccionada->id }}
       </div>
@@ -85,20 +85,20 @@
   {{-- Columna menor: bloque de botones --}}
   <div class="col-md-4 d-grid gap-2">
    
-	<button
-                                        class="btn btn-info btn-pagar"
-										style="height: 80px;"
+        <button
+                                        class="btn btn-dorado btn-pagar"
+                                                                                style="height: 80px;"
                                         data-bs-toggle="modal"
                                         data-bs-target="#modalPagarFactura"
                                         data-cuenta="{{ $ordenSeleccionada->id }}"
-										data-total="{{ $totalVentas }}"
+                                                                                data-total="{{ $totalVentas }}"
                                     >
                                         <i class="fa fa-credit-card me-1"></i> Pagar
                                     </button>
       
 
     @if(auth()->user()->peluqueria && auth()->user()->peluqueria->pos == 1)
-      <button id="btn-factura_post" class="btn btn-shadow-success btn-success" style="height: 80px;">
+      <button id="btn-factura_post" class="btn btn-dorado" style="height: 80px;">
         <i class="fa fa-fw me-1" title="Finalizar factura pos"></i>
         Finalizar factura pos
       </button>
@@ -106,8 +106,8 @@
 
     @if(auth()->user()->peluqueria && auth()->user()->peluqueria->cuentaCobro == 1)
   <a href="{{ route('orden_de_compras.show', $ordenSeleccionada->id) }}"
-     class="btn btn-warning text-white"
-	 style="height: 80px;"
+     class="btn btn-dorado"
+         style="height: 80px;"
      id="btn-cuenta_cobro">
     <i class="fa fa-fw me-1" title="Cuenta de cobro"></i>
     Generar cuenta de cobro
@@ -116,7 +116,7 @@
 
 
     @if(auth()->user()->peluqueria && auth()->user()->peluqueria->electronica == 1)
-      <button id="btn-factura_electronica" class="btn btn-shadow-primary btn-primary" style="width: 80px;">
+      <button id="btn-factura_electronica" class="btn btn-dorado" style="width: 80px;">
         <i class="pe-7s-news-paper me-1"></i>
         Generar factura electrónica
       </button>
@@ -160,7 +160,7 @@
                                 </option>
                             @endforeach
                         </select>
-                        <button class="btn btn-success" type="submit">
+                        <button class="btn btn-dorado" type="submit">
                             <i class="fa fa-plus me-1"></i> Agregar Venta
                         </button>
                     </div>
@@ -178,11 +178,11 @@
          4) TABLA DE VENTAS (SIEMPRE VISIBLE)
        ============================================================== --}}
 <div class="card mb-5 shadow-sm">
-    <div class="card-header text-white" style="background: linear-gradient(to right, #0053BF, #6366F1);">
+    <div class="card-header" style="background-color: #f8e5a1; color: #6c4e09;">
         <i class="fa fa-shopping-cart me-2"></i> Listado de Ventas
     </div>
     <div class="table-responsive">
-  <table class="table table-striped table-hover align-middle mb-0">
+  <table class="table table-striped table-hover align-middle mb-0 table-dorado">
     <thead class="table-light">
       <tr>
         <th>Producto (Ítem ID)</th>
@@ -254,14 +254,14 @@
 		</td>
 
         <td class="d-flex">
-          <button type="submit" class="btn btn-sm btn-primary me-2">Guardar</button> 
+          <button type="submit" class="btn btn-sm btn-dorado me-2">Guardar</button>
           </form>
 		
           <form action="{{ route('ventas.destroy', $venta->id) }}" method="POST"
                 onsubmit="return confirm('¿Eliminar esta venta?');">
             @csrf
             @method('DELETE')
-            <button type="submit" class="btn btn-sm btn-danger">Eliminar</button>
+            <button type="submit" class="btn btn-sm btn-dorado-outline">Eliminar</button>
           </form>
         </td>
       </tr>
@@ -281,7 +281,7 @@
        ============================================================== --}}
     @if($cuentaSeleccionada)
         <div class="card mb-5 shadow-sm">
-            <div class="card-header text-white" style="background: linear-gradient(to right, #0053BF, #6366F1);">
+            <div class="card-header" style="background-color: #f8e5a1; color: #6c4e09;">
                 <i class="fa fa-receipt me-2"></i> Pagos de la orden:
                 <strong class="text-warning">{{ $cuentaSeleccionada }}</strong>
             </div>
@@ -293,7 +293,7 @@
                     </div>
                 @else
                     <div class="table-responsive">
-                        <table class="table table-bordered table-hover align-middle mb-0">
+                        <table class="table table-bordered table-hover align-middle mb-0 table-dorado">
                             <thead class="table-light">
                                 <tr>
                                    
@@ -343,23 +343,48 @@
      6) MODAL DE PAGO DE FACTURA (idéntico a antes)
    ============================================================== --}}
 <style>
+    .btn-dorado {
+        background-color: #f8e5a1;
+        color: #6c4e09;
+        border: none;
+    }
+    .btn-dorado:hover {
+        background-color: #f6db81;
+        color: #6c4e09;
+    }
+    .btn-dorado-outline {
+        background-color: #fff;
+        border: 2px solid #f8e5a1;
+        color: #6c4e09;
+    }
+    .btn-dorado-outline:hover {
+        background-color: #f8e5a1;
+        color: #6c4e09;
+    }
+    .table-dorado thead {
+        background-color: #f9eec7;
+    }
+    .table-dorado tbody tr:nth-child(even) {
+        background-color: #fff8e1;
+    }
+
     /* Estilos personalizados para el modal */
     #modalPagarFactura .modal-header {
-        background-color: #2E86C1;
-        color: #fff;
+        background-color: #f8e5a1;
+        color: #6c4e09;
     }
     #modalPagarFactura .modal-title {
         font-weight: 600;
     }
     #modalPagarFactura .btn-close {
-        filter: invert(1);
+        /* sin filtro para fondo claro */
     }
 
     .btn-metodo {
         width: 100px;
         height: 90px;
-        border: 2px solid #0d6efd;
-        color: #0d6efd;
+        border: 2px solid #d4b54d;
+        color: #d4b54d;
         font-weight: 500;
         border-radius: 8px;
         transition: background-color .2s, color .2s;
@@ -368,7 +393,7 @@
         font-size: 1.4rem;
     }
     .btn-metodo:hover {
-        background-color: #0d6efd;
+        background-color: #d4b54d;
         color: #fff;
     }
 


### PR DESCRIPTION
## Summary
- replace gray card headers and buttons with pastel gold
- add btn-dorado and table-dorado styles for a refined contrast with lila

## Testing
- `npm test` (Missing script "test")
- `./vendor/bin/phpunit` (No such file or directory)

------
https://chatgpt.com/codex/tasks/task_e_68ae71f1ec74832491ebd522a160f11a