### PR TITLE
Add client search and profile history

### DIFF
--- a/resources/views/clientes/index.blade.php
+++ b/resources/views/clientes/index.blade.php
@@ -14,10 +14,11 @@
     <p class="card-subtitle">Todos los clientes registrados en el sistema.</p>
   </div>
   <div class="card-header d-flex justify-content-between align-items-center">
-    
-
+    <form action="{{ route('clientes.index') }}" method="GET" class="d-flex w-50">
+      <input type="text" name="q" value="{{ request('q') }}" class="form-control me-2" placeholder="Buscar cliente...">
+      <button type="submit" class="btn btn-secondary">Buscar</button>
+    </form>
     <a href="{{ route('clientes.create') }}" class="btn btn-primary">Nuevo Cliente</a>
-
   </div>
 
   <div class="card-body">

--- a/resources/views/clientes/view.blade.php
+++ b/resources/views/clientes/view.blade.php
@@ -156,15 +156,45 @@
         </ul>
       </div>
     </div>
-	
-	
-   
-  </div>
+    <!-- Tarjeta: Últimas Reservas -->
+    <div class="card-custom">
+      <div class="card-header">Últimas Reservas</div>
+      <div class="card-body">
+        @if($reservas->isEmpty())
+          <p>No hay reservas recientes.</p>
+        @else
+          <ul class="reservations-list">
+            @foreach($reservas as $reserva)
+              <li>
+                <span>{{ $reserva->fecha }}</span>
+                <span>{{ $reserva->tipo ?? $reserva->type }}</span>
+                <span>{{ optional($reserva->entrenador)->nombre }}</span>
+              </li>
+            @endforeach
+          </ul>
+        @endif
+      </div>
+    </div>
 
-
-
-  
-
+    <!-- Tarjeta: Historial de Transacciones -->
+    <div class="card-custom">
+      <div class="card-header">Historial de Transacciones</div>
+      <div class="card-body">
+        @if($transacciones->isEmpty())
+          <p>No hay transacciones.</p>
+        @else
+          <ul class="reservations-list">
+            @foreach($transacciones as $tx)
+              <li>
+                <span>{{ $tx->fecha_hora }}</span>
+                <span>Orden #{{ $tx->id }}</span>
+                <span>${{ number_format($tx->ventas->sum('valor_total'), 0, ',', '.') }}</span>
+              </li>
+            @endforeach
+          </ul>
+        @endif
+      </div>
+    </div>
   </div>
 </div>
 @endsection


### PR DESCRIPTION
## Summary
- allow filtering clients by query on index page
- show recent reservations and transaction history on client profile

## Testing
- `php artisan test` *(fails: vendor/autoload.php missing)*
- `composer install --no-progress --no-interaction` *(fails: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68ae867d2e3c8324bf7a4a4f58919b34