### PR TITLE
feat: add inventory management for items

### DIFF
--- a/app/Models/InventarioHistorial.php
+++ b/app/Models/InventarioHistorial.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\DB;
+
+class InventarioHistorial extends Model
+{
+    use HasFactory;
+
+    protected $connection = 'tenant';
+    protected $table = 'inventario_historial';
+
+    protected $fillable = [
+        'item_id',
+        'cambio',
+        'descripcion',
+    ];
+
+    protected static function booted()
+    {
+        // Ajustar conexión tenant según el usuario autenticado
+        if ($user = Auth::user()) {
+            $dbName = $user->peluqueria->db;
+            Config::set('database.connections.tenant.database', $dbName);
+            DB::purge('tenant');
+            DB::reconnect('tenant');
+        }
+    }
+
+    public function item()
+    {
+        return $this->belongsTo(Item::class);
+    }
+}

--- a/app/Models/Item.php
+++ b/app/Models/Item.php
@@ -7,6 +7,7 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\DB;
+use App\Models\InventarioHistorial;
 
 class Item extends Model
 {
@@ -38,8 +39,14 @@ class Item extends Model
     protected $fillable = [
         'nombre',
         'cantidad',
+        'costo',
         'valor',
         'tipo',
         'area',
     ];
+
+    public function movimientos()
+    {
+        return $this->hasMany(InventarioHistorial::class);
+    }
 }

--- a/database/migrations/tenant/2025_07_10_215716_create_inventario_historial_table.php
+++ b/database/migrations/tenant/2025_07_10_215716_create_inventario_historial_table.php
@@ -11,14 +11,11 @@ return new class extends Migration
      */
     public function up(): void
     {
-        Schema::create('items', function (Blueprint $table) {
+        Schema::create('inventario_historial', function (Blueprint $table) {
             $table->id();
-            $table->string('nombre', 300);
-            $table->integer('cantidad')->nullable();
-            $table->decimal('costo', 10, 2)->nullable();
-            $table->decimal('valor', 10, 2)->nullable();
-            $table->integer('tipo')->nullable();
-            $table->integer('area')->nullable();
+            $table->foreignId('item_id')->constrained('items');
+            $table->integer('cambio');
+            $table->string('descripcion')->nullable();
             $table->timestamps();
         });
     }
@@ -28,6 +25,6 @@ return new class extends Migration
      */
     public function down(): void
     {
-        Schema::dropIfExists('items');
+        Schema::dropIfExists('inventario_historial');
     }
 };

--- a/resources/views/items/add-stock.blade.php
+++ b/resources/views/items/add-stock.blade.php
@@ -1,0 +1,30 @@
+@extends('layouts.vertical', ['subtitle' => 'Agregar Unidades'])
+
+@section('content')
+<div class="container">
+    <h1 class="mb-4">Agregar Unidades a {{ $item->nombre }}</h1>
+
+    @if ($errors->any())
+        <div class="alert alert-danger">
+            <ul class="mb-0">
+                @foreach ($errors->all() as $error)
+                    <li>{{ $error }}</li>
+                @endforeach
+            </ul>
+        </div>
+    @endif
+
+    <form action="{{ route('items.add-units', $item) }}" method="POST">
+        @csrf
+        <div class="mb-3">
+            <label for="cantidad" class="form-label">Cantidad a agregar</label>
+            <input type="number" name="cantidad" id="cantidad" class="form-control @error('cantidad') is-invalid @enderror" min="1" required>
+            @error('cantidad')
+                <div class="invalid-feedback">{{ $message }}</div>
+            @enderror
+        </div>
+        <button type="submit" class="btn btn-primary">Agregar</button>
+        <a href="{{ route('items.show', $item) }}" class="btn btn-secondary">Cancelar</a>
+    </form>
+</div>
+@endsection

--- a/resources/views/items/create.blade.php
+++ b/resources/views/items/create.blade.php
@@ -3,7 +3,7 @@
 
 @section('content')
 <div class="container">
-    <h1 class="mb-4">Crear Servicio</h1>
+    <h1 class="mb-4">Crear Ítem</h1>
 
     {{-- Mostrar errores de validación --}}
     @if ($errors->any())
@@ -31,37 +31,105 @@
 
 
         <div class="mb-3">
-            <label for="valor" class="form-label">Valor</label>
-            <input type="number" step="0.01" name="valor" id="valor"
-                   class="form-control @error('valor') is-invalid @enderror"
-                   value="{{ old('valor', 0) }}" min="0" required>
-            @error('valor')
-                <div class="invalid-feedback">{{ $message }}</div>
-            @enderror
-        </div>
-<?php /*
-        <div class="mb-3">
             <label for="tipo" class="form-label">Tipo</label>
-            <input type="text" name="tipo" id="tipo"
-                   class="form-control @error('tipo') is-invalid @enderror"
-                   value="{{ old('tipo') }}" required>
-            @error('tipo')
+            <select name="tipo" id="tipo" class="form-control">
+                <option value="0" {{ old('tipo') == '0' ? 'selected' : '' }}>Servicio</option>
+                <option value="1" {{ old('tipo') == '1' ? 'selected' : '' }}>Producto</option>
+            </select>
+        </div>
+
+        <div class="row">
+            <div class="mb-3 col-md-6">
+                <label for="valor" class="form-label">Valor</label>
+                <input type="text" name="valor" id="valor"
+                       class="form-control currency-input @error('valor') is-invalid @enderror"
+                       value="{{ old('valor', 0) }}" required>
+                @error('valor')
+                    <div class="invalid-feedback">{{ $message }}</div>
+                @enderror
+            </div>
+            <div class="mb-3 col-md-6" id="costo-field" style="display:none;">
+                <label for="costo" class="form-label">Costo</label>
+                <input type="text" name="costo" id="costo"
+                       class="form-control currency-input @error('costo') is-invalid @enderror"
+                       value="{{ old('costo', 0) }}">
+                @error('costo')
+                    <div class="invalid-feedback">{{ $message }}</div>
+                @enderror
+            </div>
+        </div>
+
+        <div class="mb-3" id="cantidad-field" style="display:none;">
+            <label for="cantidad" class="form-label">Cantidad</label>
+            <input type="number" name="cantidad" id="cantidad" class="form-control @error('cantidad') is-invalid @enderror" value="{{ old('cantidad', 0) }}" min="0">
+            @error('cantidad')
                 <div class="invalid-feedback">{{ $message }}</div>
             @enderror
         </div>
 
         <div class="mb-3">
             <label for="area" class="form-label">Área</label>
-            <input type="text" name="area" id="area"
-                   class="form-control @error('area') is-invalid @enderror"
-                   value="{{ old('area') }}" required>
+            <input type="text" name="area" id="area" class="form-control @error('area') is-invalid @enderror" value="{{ old('area') }}">
             @error('area')
                 <div class="invalid-feedback">{{ $message }}</div>
             @enderror
         </div>
-*/ ?>
+
         <button type="submit" class="btn btn-success">Guardar</button>
         <a href="{{ route('items.index') }}" class="btn btn-secondary">Cancelar</a>
     </form>
 </div>
+    <script>
+        document.addEventListener('DOMContentLoaded', function () {
+            const tipo = document.getElementById('tipo');
+            const costoField = document.getElementById('costo-field');
+            const cantidadField = document.getElementById('cantidad-field');
+            const currencyInputs = document.querySelectorAll('.currency-input');
+
+            function toggleFields() {
+                const isProduct = tipo.value === '1';
+                costoField.style.display = isProduct ? 'block' : 'none';
+                cantidadField.style.display = isProduct ? 'block' : 'none';
+            }
+
+            function formatCOP(value) {
+                if (!value) return '';
+                let n = parseFloat(value.toString()
+                    .replace(/[^0-9\.\,]/g, '')
+                    .replace(/,/g, '.'));
+                if (isNaN(n)) return '';
+                return n.toLocaleString('es-CO', { style: 'currency', currency: 'COP' });
+            }
+
+            function parseCOP(formatted) {
+                if (!formatted) return 0;
+                let plain = formatted
+                    .replace(/[^0-9\.\,]/g, '')
+                    .replace(/\./g, '')
+                    .replace(/,/g, '.');
+                let n = parseFloat(plain);
+                return isNaN(n) ? 0 : n;
+            }
+
+            currencyInputs.forEach(input => {
+                input.value = formatCOP(input.value);
+                input.addEventListener('blur', function() {
+                    this.value = formatCOP(this.value);
+                });
+                input.addEventListener('focus', function() {
+                    let num = parseCOP(this.value);
+                    this.value = num ? num.toFixed(2).replace('.', ',') : '';
+                });
+            });
+
+            document.querySelector('form').addEventListener('submit', function () {
+                currencyInputs.forEach(input => {
+                    input.value = parseCOP(input.value);
+                });
+            });
+
+            tipo.addEventListener('change', toggleFields);
+            toggleFields();
+        });
+    </script>
 @endsection

--- a/resources/views/items/edit.blade.php
+++ b/resources/views/items/edit.blade.php
@@ -31,31 +31,40 @@
         </div>
 
         <div class="mb-3">
+            <label for="tipo" class="form-label">Tipo</label>
+            <select name="tipo" id="tipo" class="form-control">
+                <option value="0" {{ old('tipo', $item->tipo) == 0 ? 'selected' : '' }}>Servicio</option>
+                <option value="1" {{ old('tipo', $item->tipo) == 1 ? 'selected' : '' }}>Producto</option>
+            </select>
+        </div>
+
+        <div class="row">
+            <div class="mb-3 col-md-6">
+                <label for="valor" class="form-label">Valor</label>
+                <input type="text" name="valor" id="valor"
+                       class="form-control currency-input @error('valor') is-invalid @enderror"
+                       value="{{ old('valor', $item->valor) }}" required>
+                @error('valor')
+                    <div class="invalid-feedback">{{ $message }}</div>
+                @enderror
+            </div>
+            <div class="mb-3 col-md-6" id="costo-field" style="display:none;">
+                <label for="costo" class="form-label">Costo</label>
+                <input type="text" name="costo" id="costo"
+                       class="form-control currency-input @error('costo') is-invalid @enderror"
+                       value="{{ old('costo', $item->costo) }}">
+                @error('costo')
+                    <div class="invalid-feedback">{{ $message }}</div>
+                @enderror
+            </div>
+        </div>
+
+        <div class="mb-3" id="cantidad-field" style="display:none;">
             <label for="cantidad" class="form-label">Cantidad</label>
             <input type="number" name="cantidad" id="cantidad"
                    class="form-control @error('cantidad') is-invalid @enderror"
-                   value="{{ old('cantidad', $item->cantidad) }}" min="0" required>
+                   value="{{ old('cantidad', $item->cantidad) }}" min="0">
             @error('cantidad')
-                <div class="invalid-feedback">{{ $message }}</div>
-            @enderror
-        </div>
-
-        <div class="mb-3">
-            <label for="valor" class="form-label">Valor</label>
-            <input type="number" step="0.01" name="valor" id="valor"
-                   class="form-control @error('valor') is-invalid @enderror"
-                   value="{{ old('valor', $item->valor) }}" min="0" required>
-            @error('valor')
-                <div class="invalid-feedback">{{ $message }}</div>
-            @enderror
-        </div>
-
-        <div class="mb-3">
-            <label for="tipo" class="form-label">Tipo</label>
-            <input type="text" name="tipo" id="tipo"
-                   class="form-control @error('tipo') is-invalid @enderror"
-                   value="{{ old('tipo', $item->tipo) }}" required>
-            @error('tipo')
                 <div class="invalid-feedback">{{ $message }}</div>
             @enderror
         </div>
@@ -64,7 +73,7 @@
             <label for="area" class="form-label">Área</label>
             <input type="text" name="area" id="area"
                    class="form-control @error('area') is-invalid @enderror"
-                   value="{{ old('area', $item->area) }}" required>
+                   value="{{ old('area', $item->area) }}">
             @error('area')
                 <div class="invalid-feedback">{{ $message }}</div>
             @enderror
@@ -74,4 +83,57 @@
         <a href="{{ route('items.index') }}" class="btn btn-secondary">Cancelar</a>
     </form>
 </div>
+<script>
+    document.addEventListener('DOMContentLoaded', function () {
+        const tipo = document.getElementById('tipo');
+        const costoField = document.getElementById('costo-field');
+        const cantidadField = document.getElementById('cantidad-field');
+        const currencyInputs = document.querySelectorAll('.currency-input');
+
+        function toggleFields() {
+            const isProduct = tipo.value === '1';
+            costoField.style.display = isProduct ? 'block' : 'none';
+            cantidadField.style.display = isProduct ? 'block' : 'none';
+        }
+
+        function formatCOP(value) {
+            if (!value) return '';
+            let n = parseFloat(value.toString()
+                .replace(/[^0-9\.\,]/g, '')
+                .replace(/,/g, '.'));
+            if (isNaN(n)) return '';
+            return n.toLocaleString('es-CO', { style: 'currency', currency: 'COP' });
+        }
+
+        function parseCOP(formatted) {
+            if (!formatted) return 0;
+            let plain = formatted
+                .replace(/[^0-9\.\,]/g, '')
+                .replace(/\./g, '')
+                .replace(/,/g, '.');
+            let n = parseFloat(plain);
+            return isNaN(n) ? 0 : n;
+        }
+
+        currencyInputs.forEach(input => {
+            input.value = formatCOP(input.value);
+            input.addEventListener('blur', function () {
+                this.value = formatCOP(this.value);
+            });
+            input.addEventListener('focus', function () {
+                let num = parseCOP(this.value);
+                this.value = num ? num.toFixed(2).replace('.', ',') : '';
+            });
+        });
+
+        document.querySelector('form').addEventListener('submit', function () {
+            currencyInputs.forEach(input => {
+                input.value = parseCOP(input.value);
+            });
+        });
+
+        tipo.addEventListener('change', toggleFields);
+        toggleFields();
+    });
+</script>
 @endsection

--- a/resources/views/items/index.blade.php
+++ b/resources/views/items/index.blade.php
@@ -2,7 +2,7 @@
 
 @section('content')
 <div class="container">
-    <h1 class="mb-4">Listado de Servicioss</h1>
+    <h1 class="mb-4">Listado de Ítems</h1>
 
     @if (session('success'))
         <div class="alert alert-success">
@@ -10,7 +10,13 @@
         </div>
     @endif
 
-    <a href="{{ route('items.create') }}" class="btn btn-primary mb-3">Nuevo Servicio</a>
+    <div class="d-flex justify-content-between mb-3">
+        <form method="GET" action="{{ route('items.index') }}" class="d-flex w-50">
+            <input type="text" name="search" class="form-control me-2" placeholder="Buscar..." value="{{ request('search') }}">
+            <button type="submit" class="btn btn-secondary">Buscar</button>
+        </form>
+        <a href="{{ route('items.create') }}" class="btn btn-primary">Nuevo Ítem</a>
+    </div>
 
     @if ($items->count())
         <table class="table table-striped">
@@ -19,6 +25,9 @@
                     <th>ID</th>
                     <th>Nombre</th>
                     <th>Valor</th>
+                    <th>Tipo</th>
+                    <th>Cantidad</th>
+                    <th>Costo</th>
                     <th>Acciones</th>
                 </tr>
             </thead>
@@ -28,16 +37,18 @@
                         <td>{{ $item->id }}</td>
                         <td>{{ $item->nombre }}</td>
                         <td>{{ number_format($item->valor, 2, ',', '.') }}</td>
-                       
+                        <td>{{ $item->tipo == 1 ? 'Producto' : 'Servicio' }}</td>
+                        <td>{{ $item->tipo == 1 ? $item->cantidad : '-' }}</td>
+                        <td>{{ $item->tipo == 1 ? number_format($item->costo, 2, ',', '.') : '-' }}</td>
+
                         <td>
                             <a href="{{ route('items.show', $item) }}" class="btn btn-sm btn-secondary">Ver</a>
-                            <a href="{{ route('items.edit', $item) }}" class="btn btn-sm btn-warning">Editar</a>
+                            <a href="{{ route('items.edit', $item) }}" class="btn btn-sm btn-primary">Editar</a>
 
-                            <form action="{{ route('items.destroy', $item) }}" method="POST" class="d-inline"
-                                  onsubmit="return confirm('¿Eliminar este ítem?');">
+                            <form action="{{ route('items.destroy', $item) }}" method="POST" class="d-inline" onsubmit="return confirm('¿Eliminar este ítem?');">
                                 @csrf
                                 @method('DELETE')
-                                <button class="btn btn-sm btn-danger" type="submit">Eliminar</button>
+                                <button class="btn btn-sm btn-secondary" type="submit">Eliminar</button>
                             </form>
                         </td>
                     </tr>
@@ -46,7 +57,7 @@
         </table>
 
         {{-- Paginación --}}
-        {{ $items->links() }}
+        {{ $items->links('pagination::bootstrap-5') }}
     @else
         <p>No hay ítems registrados.</p>
     @endif

--- a/resources/views/items/show.blade.php
+++ b/resources/views/items/show.blade.php
@@ -5,19 +5,62 @@
 <div class="container">
     <h1 class="mb-4">Detalle del Ítem #{{ $item->id }}</h1>
 
-    <div class="card mb-4">
-        <div class="card-body">
-            <p><strong>Nombre:</strong> {{ $item->nombre }}</p>
-            <p><strong>Cantidad:</strong> {{ $item->cantidad }}</p>
-            <p><strong>Valor:</strong> {{ number_format($item->valor, 2, ',', '.') }}</p>
-            <p><strong>Tipo:</strong> {{ $item->tipo }}</p>
-            <p><strong>Área:</strong> {{ $item->area }}</p>
-            <p><strong>Creado:</strong> {{ $item->created_at->format('d/m/Y H:i') }}</p>
-            <p><strong>Última actualización:</strong> {{ $item->updated_at->format('d/m/Y H:i') }}</p>
-        </div>
+    <div class="mb-3">
+        @if($item->tipo == 1)
+            <a href="{{ route('items.add-units-form', $item) }}" class="btn" style="background-color:#6f42c1; color:white;">Agregar unidades</a>
+        @endif
+        <a href="{{ route('items.edit', $item) }}" class="btn" style="background-color:#6f42c1; color:white;">Editar</a>
+        <a href="{{ route('items.index') }}" class="btn btn-secondary">Volver al listado</a>
     </div>
 
-    <a href="{{ route('items.edit', $item) }}" class="btn btn-warning">Editar</a>
-    <a href="{{ route('items.index') }}" class="btn btn-secondary">Volver al listado</a>
+    <div class="row">
+        <div class="col-md-6">
+            <div class="card mb-4" style="background-color:#f8f9fa; border-color:#6f42c1;">
+                <div class="card-body">
+                    <p><strong>Nombre:</strong> {{ $item->nombre }}</p>
+                    @if($item->tipo == 1)
+                        <p><strong>Costo:</strong> {{ number_format($item->costo, 2, ',', '.') }}</p>
+                        <p><strong>Cantidad:</strong> {{ $item->cantidad }}</p>
+                    @endif
+                    <p><strong>Valor:</strong> {{ number_format($item->valor, 2, ',', '.') }}</p>
+                    <p><strong>Tipo:</strong> {{ $item->tipo == 1 ? 'Producto' : 'Servicio' }}</p>
+                    <p><strong>Área:</strong> {{ $item->area }}</p>
+                    <p><strong>Creado:</strong> {{ $item->created_at->format('d/m/Y H:i') }}</p>
+                    <p><strong>Última actualización:</strong> {{ $item->updated_at->format('d/m/Y H:i') }}</p>
+                </div>
+            </div>
+        </div>
+        @if($item->tipo == 1)
+        <div class="col-md-6">
+            <div class="card mb-4" style="background-color:#f8f9fa; border-color:#6f42c1;">
+                <div class="card-body">
+                    <h2 class="mb-3" style="color:#6f42c1;">Historial de inventario</h2>
+                    @if($item->movimientos->count())
+                    <table class="table">
+                        <thead>
+                            <tr>
+                                <th>Fecha</th>
+                                <th>Cambio</th>
+                                <th>Descripción</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            @foreach($item->movimientos as $mov)
+                                <tr>
+                                    <td>{{ $mov->created_at->format('d/m/Y H:i') }}</td>
+                                    <td>{{ $mov->cambio }}</td>
+                                    <td>{{ $mov->descripcion }}</td>
+                                </tr>
+                            @endforeach
+                        </tbody>
+                    </table>
+                    @else
+                        <p>No hay movimientos de inventario.</p>
+                    @endif
+                </div>
+            </div>
+        </div>
+        @endif
+    </div>
 </div>
 @endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -125,6 +125,8 @@ Route::get('/', function () {
     return redirect()->route('items.index');
 });
 Route::resource('items', ItemController::class);
+Route::get('items/{item}/agregar-unidades', [ItemController::class, 'addUnitsForm'])->name('items.add-units-form');
+Route::post('items/{item}/agregar-unidades', [ItemController::class, 'addUnits'])->name('items.add-units');
 Route::get('/calendar', [ReservaController::class, 'calendar'])->name('reservas.calendar');
 Route::get('/reservas.json', [ReservaController::class, 'events'])
      ->name('reservas.events');


### PR DESCRIPTION
## Summary
- add search filtering to item index and controller
- show item type with conditional quantity and cost and grey/lilac buttons
- use bootstrap pagination links on items index to avoid oversized arrow icons

## Testing
- `composer install --no-interaction` (fails: CONNECT tunnel failed, response 403)
- `php artisan test` (fails: Failed opening required 'vendor/autoload.php')
- `npm test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_68b075353d948324bf06262d1f8bd5c2