### PR TITLE
Fix client selection when editing reservations

### DIFF
--- a/app/Http/Controllers/ReservaController.php
+++ b/app/Http/Controllers/ReservaController.php
@@ -131,9 +131,11 @@ class ReservaController extends Controller
                 'tipo'          => $r->tipo,              // reserva | torneo | clase
                 'estado'        => $r->estado,            // confirmada | pendiente
                 'entrenador_id' => $r->entrenador_id,
+                'cliente_id'    => $r->cliente_id,
             ],
             'cancha_id'       => $r->cancha_id,
             'entrenador_id'   => $r->entrenador_id,
+            'cliente_id'      => $r->cliente_id,
         ];
 
       

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -199,7 +199,11 @@ const horaSelect  = document.getElementById('reservaHora');
 
     //  inicioInput.value    = dt.toISOString().slice(0,16);
       durationSelect.value = '60';
-      clienteSelect.value   = '';
+      if (clienteSelect.tomselect) {
+        clienteSelect.tomselect.clear(true);
+      } else {
+        clienteSelect.value = '';
+      }
       entrenadorSelect.value = '';
       responsableInput.value = '';
           fechaInput.value = info.startStr.split('T')[0];
@@ -247,6 +251,11 @@ form.action                          = '/reservas/' + ev.id;
      // inicioInput.value                    = ev.start.toISOString().slice(0,16);
       durationSelect.value                 = props.duration;
       entrenadorSelect.value              = props.entrenador_id || '';
+      if (clienteSelect.tomselect) {
+        clienteSelect.tomselect.setValue(props.cliente_id || '', true);
+      } else {
+        clienteSelect.value = props.cliente_id || '';
+      }
 
         
       


### PR DESCRIPTION
## Summary
- include cliente_id in reservation event payload
- ensure reservation modal sets existing client when editing

## Testing
- `npm test` *(fails: Missing script "test")*
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b7221db8d08324b4e2a8067b725df8