### PR TITLE
Add areas and identification type management

### DIFF
--- a/app/Http/Controllers/AreaController.php
+++ b/app/Http/Controllers/AreaController.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Area;
+use Illuminate\Http\Request;
+
+class AreaController extends Controller
+{
+    public function index()
+    {
+        $areas = Area::orderBy('descripcion')->paginate(10);
+
+        return view('areas.index', compact('areas'));
+    }
+
+    public function create()
+    {
+        return view('areas.create');
+    }
+
+    public function store(Request $request)
+    {
+        $data = $request->validate([
+            'descripcion' => 'required|string|max:300',
+        ]);
+
+        Area::create($data);
+
+        return redirect()
+            ->route('areas.index')
+            ->with('success', 'Área creada correctamente.');
+    }
+
+    public function edit(Area $area)
+    {
+        return view('areas.edit', compact('area'));
+    }
+
+    public function update(Request $request, Area $area)
+    {
+        $data = $request->validate([
+            'descripcion' => 'required|string|max:300',
+        ]);
+
+        $area->update($data);
+
+        return redirect()
+            ->route('areas.index')
+            ->with('success', 'Área actualizada correctamente.');
+    }
+}

--- a/app/Http/Controllers/TipoIdentificacionController.php
+++ b/app/Http/Controllers/TipoIdentificacionController.php
@@ -3,64 +3,59 @@
 namespace App\Http\Controllers;
 
 use App\Models\TipoIdentificacion;
-use App\Http\Controllers\Controller;
 use Illuminate\Http\Request;
 
 class TipoIdentificacionController extends Controller
 {
-    /**
-     * Display a listing of the resource.
-     */
     public function index()
     {
-        //
+        $tiposIdentificacion = TipoIdentificacion::orderBy('id')->paginate(10);
+
+        return view('tipo-identificaciones.index', compact('tiposIdentificacion'));
     }
 
-    /**
-     * Show the form for creating a new resource.
-     */
     public function create()
     {
-        //
+        return view('tipo-identificaciones.create');
     }
 
-    /**
-     * Store a newly created resource in storage.
-     */
     public function store(Request $request)
     {
-        //
+        $data = $request->validate([
+            'tipo' => 'required|string|max:100',
+        ]);
+
+        TipoIdentificacion::create($data);
+
+        return redirect()
+            ->route('tipo-identificaciones.index')
+            ->with('success', 'Tipo de identificación creado correctamente.');
     }
 
-    /**
-     * Display the specified resource.
-     */
-    public function show(TipoIdentificacion $tipoIdentificacion)
-    {
-        //
-    }
-
-    /**
-     * Show the form for editing the specified resource.
-     */
     public function edit(TipoIdentificacion $tipoIdentificacion)
     {
-        //
+        return view('tipo-identificaciones.edit', compact('tipoIdentificacion'));
     }
 
-    /**
-     * Update the specified resource in storage.
-     */
     public function update(Request $request, TipoIdentificacion $tipoIdentificacion)
     {
-        //
+        $data = $request->validate([
+            'tipo' => 'required|string|max:100',
+        ]);
+
+        $tipoIdentificacion->update($data);
+
+        return redirect()
+            ->route('tipo-identificaciones.index')
+            ->with('success', 'Tipo de identificación actualizado correctamente.');
     }
 
-    /**
-     * Remove the specified resource from storage.
-     */
     public function destroy(TipoIdentificacion $tipoIdentificacion)
     {
-        //
+        $tipoIdentificacion->delete();
+
+        return redirect()
+            ->route('tipo-identificaciones.index')
+            ->with('success', 'Tipo de identificación eliminado correctamente.');
     }
 }

--- a/app/Models/Area.php
+++ b/app/Models/Area.php
@@ -7,14 +7,14 @@ use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\DB;
 
-class TipoIdentificacion extends Model
+class Area extends Model
 {
     protected $connection = 'tenant';
 
-    protected $table = 'tipo_identificacions';
+    protected $table = 'areas';
 
     protected $fillable = [
-        'tipo',
+        'descripcion',
     ];
 
     public $timestamps = false;

--- a/app/Models/Item.php
+++ b/app/Models/Item.php
@@ -8,6 +8,7 @@ use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\DB;
 use App\Models\InventarioHistorial;
+use App\Models\Area;
 
 class Item extends Model
 {
@@ -45,8 +46,18 @@ class Item extends Model
         'area',
     ];
 
+    protected $casts = [
+        'valor' => 'decimal:2',
+        'costo' => 'decimal:2',
+    ];
+
     public function movimientos()
     {
         return $this->hasMany(InventarioHistorial::class);
+    }
+
+    public function areaRelation()
+    {
+        return $this->belongsTo(Area::class, 'area');
     }
 }

--- a/database/migrations/tenant/2025_07_10_215716_create_areas_table.php
+++ b/database/migrations/tenant/2025_07_10_215716_create_areas_table.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('areas', function (Blueprint $table) {
+            $table->id();
+            $table->string('descripcion', 300);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('areas');
+    }
+};

--- a/resources/views/areas/_form.blade.php
+++ b/resources/views/areas/_form.blade.php
@@ -1,0 +1,8 @@
+@csrf
+<div class="mb-3">
+    <label for="descripcion" class="form-label">Descripción</label>
+    <input type="text" name="descripcion" id="descripcion" class="form-control @error('descripcion') is-invalid @enderror" value="{{ old('descripcion', $area->descripcion ?? '') }}" required maxlength="300">
+    @error('descripcion')
+        <div class="invalid-feedback">{{ $message }}</div>
+    @enderror
+</div>

--- a/resources/views/areas/create.blade.php
+++ b/resources/views/areas/create.blade.php
@@ -1,0 +1,18 @@
+@extends('layouts.vertical', ['subtitle' => 'Crear Área'])
+
+@section('content')
+<div class="container">
+    <h1 class="mb-4">Crear Área</h1>
+    <div class="card">
+        <div class="card-body">
+            <form action="{{ route('areas.store') }}" method="POST">
+                @include('areas._form')
+                <div class="d-flex gap-2">
+                    <button type="submit" class="btn btn-success">Guardar</button>
+                    <a href="{{ route('areas.index') }}" class="btn btn-secondary">Cancelar</a>
+                </div>
+            </form>
+        </div>
+    </div>
+</div>
+@endsection

--- a/resources/views/areas/edit.blade.php
+++ b/resources/views/areas/edit.blade.php
@@ -1,0 +1,19 @@
+@extends('layouts.vertical', ['subtitle' => 'Editar Área'])
+
+@section('content')
+<div class="container">
+    <h1 class="mb-4">Editar Área</h1>
+    <div class="card">
+        <div class="card-body">
+            <form action="{{ route('areas.update', $area) }}" method="POST">
+                @method('PUT')
+                @include('areas._form')
+                <div class="d-flex gap-2">
+                    <button type="submit" class="btn btn-primary">Actualizar</button>
+                    <a href="{{ route('areas.index') }}" class="btn btn-secondary">Cancelar</a>
+                </div>
+            </form>
+        </div>
+    </div>
+</div>
+@endsection

--- a/resources/views/areas/index.blade.php
+++ b/resources/views/areas/index.blade.php
@@ -1,0 +1,50 @@
+@extends('layouts.vertical', ['subtitle' => 'Listado de Áreas'])
+
+@section('content')
+<div class="container">
+    <div class="d-flex justify-content-between align-items-center mb-4">
+        <h1 class="h3 mb-0">Áreas</h1>
+        <a href="{{ route('areas.create') }}" class="btn btn-primary">Nueva Área</a>
+    </div>
+
+    @if (session('success'))
+        <div class="alert alert-success">{{ session('success') }}</div>
+    @endif
+
+    <div class="card">
+        <div class="card-body p-0">
+            <div class="table-responsive">
+                <table class="table table-striped mb-0">
+                    <thead>
+                        <tr>
+                            <th class="text-center" style="width: 80px;">ID</th>
+                            <th>Descripción</th>
+                            <th class="text-end" style="width: 160px;">Acciones</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        @forelse ($areas as $area)
+                            <tr>
+                                <td class="text-center">{{ $area->id }}</td>
+                                <td>{{ $area->descripcion }}</td>
+                                <td class="text-end">
+                                    <a href="{{ route('areas.edit', $area) }}" class="btn btn-sm btn-primary">Editar</a>
+                                </td>
+                            </tr>
+                        @empty
+                            <tr>
+                                <td colspan="3" class="text-center py-4">No hay áreas registradas.</td>
+                            </tr>
+                        @endforelse
+                    </tbody>
+                </table>
+            </div>
+        </div>
+        @if ($areas->hasPages())
+            <div class="card-footer">
+                {{ $areas->links('pagination::bootstrap-5') }}
+            </div>
+        @endif
+    </div>
+</div>
+@endsection

--- a/resources/views/items/create.blade.php
+++ b/resources/views/items/create.blade.php
@@ -74,7 +74,14 @@
 
         <div class="mb-3">
             <label for="area" class="form-label">Área</label>
-            <input type="text" name="area" id="area" class="form-control @error('area') is-invalid @enderror" value="{{ old('area') }}">
+            <select name="area" id="area" class="form-select @error('area') is-invalid @enderror">
+                <option value="">Seleccione un área</option>
+                @foreach ($areas as $area)
+                    <option value="{{ $area->id }}" {{ old('area') == $area->id ? 'selected' : '' }}>
+                        {{ $area->descripcion }}
+                    </option>
+                @endforeach
+            </select>
             @error('area')
                 <div class="invalid-feedback">{{ $message }}</div>
             @enderror
@@ -100,7 +107,7 @@
             }
 
             function formatCOP(value) {
-                if (!value) return '';
+                if (value === null || value === undefined || value === '') return '';
                 let n = parseFloat(value.toString()
                     .replace(/[^0-9\.\,]/g, '')
                     .replace(/,/g, '.'));
@@ -109,13 +116,13 @@
             }
 
             function parseCOP(formatted) {
-                if (!formatted) return 0;
+                if (formatted === null || formatted === undefined || formatted === '') return null;
                 let plain = formatted
                     .replace(/[^0-9\.\,]/g, '')
                     .replace(/\./g, '')
                     .replace(/,/g, '.');
                 let n = parseFloat(plain);
-                return isNaN(n) ? 0 : n;
+                return isNaN(n) ? null : n;
             }
 
             currencyInputs.forEach(input => {
@@ -125,13 +132,14 @@
                 });
                 input.addEventListener('focus', function() {
                     let num = parseCOP(this.value);
-                    this.value = num ? num.toFixed(2).replace('.', ',') : '';
+                    this.value = num !== null ? num.toFixed(2).replace('.', ',') : '';
                 });
             });
 
             document.querySelector('form').addEventListener('submit', function () {
                 currencyInputs.forEach(input => {
-                    input.value = parseCOP(input.value);
+                    const parsed = parseCOP(input.value);
+                    input.value = parsed !== null ? parsed.toFixed(2) : '';
                 });
             });
 

--- a/resources/views/items/edit.blade.php
+++ b/resources/views/items/edit.blade.php
@@ -73,9 +73,15 @@
 
         <div class="mb-3">
             <label for="area" class="form-label">Área</label>
-            <input type="text" name="area" id="area"
-                   class="form-control @error('area') is-invalid @enderror"
-                   value="{{ old('area', $item->area) }}">
+            <select name="area" id="area"
+                    class="form-select @error('area') is-invalid @enderror">
+                <option value="">Seleccione un área</option>
+                @foreach ($areas as $area)
+                    <option value="{{ $area->id }}" {{ old('area', $item->area) == $area->id ? 'selected' : '' }}>
+                        {{ $area->descripcion }}
+                    </option>
+                @endforeach
+            </select>
             @error('area')
                 <div class="invalid-feedback">{{ $message }}</div>
             @enderror
@@ -101,7 +107,7 @@
         }
 
         function formatCOP(value) {
-            if (!value) return '';
+            if (value === null || value === undefined || value === '') return '';
             let n = parseFloat(value.toString()
                 .replace(/[^0-9\.\,]/g, '')
                 .replace(/,/g, '.'));
@@ -110,13 +116,13 @@
         }
 
         function parseCOP(formatted) {
-            if (!formatted) return 0;
+            if (formatted === null || formatted === undefined || formatted === '') return null;
             let plain = formatted
                 .replace(/[^0-9\.\,]/g, '')
                 .replace(/\./g, '')
                 .replace(/,/g, '.');
             let n = parseFloat(plain);
-            return isNaN(n) ? 0 : n;
+            return isNaN(n) ? null : n;
         }
 
         currencyInputs.forEach(input => {
@@ -126,13 +132,14 @@
             });
             input.addEventListener('focus', function () {
                 let num = parseCOP(this.value);
-                this.value = num ? num.toFixed(2).replace('.', ',') : '';
+                this.value = num !== null ? num.toFixed(2).replace('.', ',') : '';
             });
         });
 
         document.querySelector('form').addEventListener('submit', function () {
             currencyInputs.forEach(input => {
-                input.value = parseCOP(input.value);
+                const parsed = parseCOP(input.value);
+                input.value = parsed !== null ? parsed.toFixed(2) : '';
             });
         });
 

--- a/resources/views/items/index.blade.php
+++ b/resources/views/items/index.blade.php
@@ -26,6 +26,7 @@
                     <th>Nombre</th>
                     <th>Valor</th>
                     <th>Tipo</th>
+                    <th>Área</th>
                     <th>Cantidad</th>
                     <th>Costo</th>
                     <th>Acciones</th>
@@ -38,6 +39,7 @@
                         <td>{{ $item->nombre }}</td>
                         <td>{{ number_format($item->valor, 2, ',', '.') }}</td>
                         <td>{{ $item->tipo == 1 ? 'Producto' : 'Servicio' }}</td>
+                        <td>{{ $item->areaRelation?->descripcion ?? 'Sin asignar' }}</td>
                         <td>{{ $item->tipo == 1 ? $item->cantidad : '-' }}</td>
                         <td>{{ $item->tipo == 1 ? number_format($item->costo, 2, ',', '.') : '-' }}</td>
 

--- a/resources/views/items/show.blade.php
+++ b/resources/views/items/show.blade.php
@@ -26,7 +26,7 @@
                     @endif
                     <p><strong>Valor:</strong> {{ number_format($item->valor, 2, ',', '.') }}</p>
                     <p><strong>Tipo:</strong> {{ $item->tipo == 1 ? 'Producto' : 'Servicio' }}</p>
-                    <p><strong>Área:</strong> {{ $item->area }}</p>
+                    <p><strong>Área:</strong> {{ optional($item->areaRelation)->descripcion ?? 'Sin asignar' }}</p>
                     <p><strong>Creado:</strong> {{ $item->created_at->format('d/m/Y H:i') }}</p>
                     <p><strong>Última actualización:</strong> {{ $item->updated_at->format('d/m/Y H:i') }}</p>
                 </div>

--- a/resources/views/layouts/partials/sidebar.blade.php
+++ b/resources/views/layouts/partials/sidebar.blade.php
@@ -87,10 +87,18 @@
                     <div class="collapse" id="sidebarLayouts">
                          <ul class="nav sub-navbar-nav">
                               <li class="sub-nav-item">
-                                  <a class="sub-nav-link" href="{{ route('deportes.index') }}" >
-                                       Deportes</a>
+                                   <a class="sub-nav-link" href="{{ route('reservas.index') }}">
+                                        Listar citas</a>
                               </li>
-                             
+                              <li class="sub-nav-item">
+                                   <a class="sub-nav-link" href="{{ route('tipo-identificaciones.index') }}">
+                                        Tipos de identificaciones</a>
+                              </li>
+                              <li class="sub-nav-item">
+                                   <a class="sub-nav-link" href="{{ route('areas.index') }}">
+                                        Listar áreas</a>
+                              </li>
+
                          </ul>
                     </div>
                </li>

--- a/resources/views/tipo-identificaciones/_form.blade.php
+++ b/resources/views/tipo-identificaciones/_form.blade.php
@@ -1,0 +1,8 @@
+@csrf
+<div class="mb-3">
+    <label for="tipo" class="form-label">Tipo</label>
+    <input type="text" name="tipo" id="tipo" class="form-control @error('tipo') is-invalid @enderror" value="{{ old('tipo', $tipoIdentificacion->tipo ?? '') }}" required maxlength="100">
+    @error('tipo')
+        <div class="invalid-feedback">{{ $message }}</div>
+    @enderror
+</div>

--- a/resources/views/tipo-identificaciones/create.blade.php
+++ b/resources/views/tipo-identificaciones/create.blade.php
@@ -1,0 +1,18 @@
+@extends('layouts.vertical', ['subtitle' => 'Nuevo tipo de identificación'])
+
+@section('content')
+<div class="container">
+    <h1 class="mb-4">Crear tipo de identificación</h1>
+    <div class="card">
+        <div class="card-body">
+            <form action="{{ route('tipo-identificaciones.store') }}" method="POST">
+                @include('tipo-identificaciones._form')
+                <div class="d-flex gap-2">
+                    <button type="submit" class="btn btn-success">Guardar</button>
+                    <a href="{{ route('tipo-identificaciones.index') }}" class="btn btn-secondary">Cancelar</a>
+                </div>
+            </form>
+        </div>
+    </div>
+</div>
+@endsection

--- a/resources/views/tipo-identificaciones/edit.blade.php
+++ b/resources/views/tipo-identificaciones/edit.blade.php
@@ -1,0 +1,19 @@
+@extends('layouts.vertical', ['subtitle' => 'Editar tipo de identificación'])
+
+@section('content')
+<div class="container">
+    <h1 class="mb-4">Editar tipo de identificación</h1>
+    <div class="card">
+        <div class="card-body">
+            <form action="{{ route('tipo-identificaciones.update', $tipoIdentificacion) }}" method="POST">
+                @method('PUT')
+                @include('tipo-identificaciones._form')
+                <div class="d-flex gap-2">
+                    <button type="submit" class="btn btn-primary">Actualizar</button>
+                    <a href="{{ route('tipo-identificaciones.index') }}" class="btn btn-secondary">Cancelar</a>
+                </div>
+            </form>
+        </div>
+    </div>
+</div>
+@endsection

--- a/resources/views/tipo-identificaciones/index.blade.php
+++ b/resources/views/tipo-identificaciones/index.blade.php
@@ -1,0 +1,55 @@
+@extends('layouts.vertical', ['subtitle' => 'Tipos de identificación'])
+
+@section('content')
+<div class="container">
+    <div class="d-flex justify-content-between align-items-center mb-4">
+        <h1 class="h3 mb-0">Tipos de identificación</h1>
+        <a href="{{ route('tipo-identificaciones.create') }}" class="btn btn-primary">Nuevo tipo</a>
+    </div>
+
+    @if (session('success'))
+        <div class="alert alert-success">{{ session('success') }}</div>
+    @endif
+
+    <div class="card">
+        <div class="card-body p-0">
+            <div class="table-responsive">
+                <table class="table table-striped mb-0">
+                    <thead>
+                        <tr>
+                            <th class="text-center" style="width: 80px;">ID</th>
+                            <th>Tipo</th>
+                            <th class="text-end" style="width: 200px;">Acciones</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        @forelse ($tiposIdentificacion as $tipo)
+                            <tr>
+                                <td class="text-center">{{ $tipo->id }}</td>
+                                <td>{{ $tipo->tipo }}</td>
+                                <td class="text-end">
+                                    <a href="{{ route('tipo-identificaciones.edit', $tipo) }}" class="btn btn-sm btn-primary">Editar</a>
+                                    <form action="{{ route('tipo-identificaciones.destroy', $tipo) }}" method="POST" class="d-inline" onsubmit="return confirm('¿Eliminar este tipo?');">
+                                        @csrf
+                                        @method('DELETE')
+                                        <button type="submit" class="btn btn-sm btn-outline-danger">Eliminar</button>
+                                    </form>
+                                </td>
+                            </tr>
+                        @empty
+                            <tr>
+                                <td colspan="3" class="text-center py-4">No hay tipos de identificación registrados.</td>
+                            </tr>
+                        @endforelse
+                    </tbody>
+                </table>
+            </div>
+        </div>
+        @if ($tiposIdentificacion->hasPages())
+            <div class="card-footer">
+                {{ $tiposIdentificacion->links('pagination::bootstrap-5') }}
+            </div>
+        @endif
+    </div>
+</div>
+@endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -21,6 +21,8 @@ use App\Http\Controllers\UsuarioController;
 use App\Http\Controllers\BancoController;
 use App\Http\Controllers\ItemController;
 use App\Http\Controllers\TipoUsuarioController;
+use App\Http\Controllers\TipoIdentificacionController;
+use App\Http\Controllers\AreaController;
 use App\Http\Controllers\SalidaController;
 use App\Http\Controllers\ProveedorController;
 use App\Http\Controllers\Admin\DashboardController;
@@ -77,6 +79,8 @@ Route::post('/ordenes/{orden}/email', [OrdendecompraController::class, 'sendEmai
 Route::resource('proveedores', ProveedorController::class);
 
 Route::resource('salidas', SalidaController::class);
+Route::resource('tipo-identificaciones', TipoIdentificacionController::class)->except(['show']);
+Route::resource('areas', AreaController::class)->except(['show', 'destroy']);
 		 
 	Route::get('/dashboard', [DashboardController::class, 'index'])
     ->name('dashboard');


### PR DESCRIPTION
## Summary
- add an Areas model, controller, migration, and views to create, list, and edit areas within the tenant connection
- finish the TipoIdentificacion CRUD flow with validation, views, and routing updates
- hook items into the new areas catalog, refine currency handling, and refresh the configuration menu links
- normalize currency amounts on the server before validating items so formatted values pass numeric rules

## Testing
- `php artisan test` *(fails: vendor/autoload.php missing and Composer install requires a GitHub token)*

------
https://chatgpt.com/codex/tasks/task_e_68d55f7806848324b3a8d04734e787a9