### PR TITLE
Add Tipocita CRUD interface

### DIFF
--- a/app/Http/Controllers/TipocitaController.php
+++ b/app/Http/Controllers/TipocitaController.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Tipocita;
+use Illuminate\Http\Request;
+
+class TipocitaController extends Controller
+{
+    /**
+     * Display a listing of the resource.
+     */
+    public function index()
+    {
+        $tipocitas = Tipocita::orderByDesc('id')->paginate(10);
+
+        return view('tipocitas.index', compact('tipocitas'));
+    }
+
+    /**
+     * Show the form for creating a new resource.
+     */
+    public function create()
+    {
+        return view('tipocitas.create');
+    }
+
+    /**
+     * Store a newly created resource in storage.
+     */
+    public function store(Request $request)
+    {
+        $data = $request->validate([
+            'nombre' => ['required', 'string', 'max:255'],
+        ]);
+
+        Tipocita::create($data);
+
+        return redirect()
+            ->route('tipocitas.index')
+            ->with('success', 'Tipo de cita creado correctamente.');
+    }
+
+    /**
+     * Show the form for editing the specified resource.
+     */
+    public function edit(Tipocita $tipocita)
+    {
+        return view('tipocitas.edit', compact('tipocita'));
+    }
+
+    /**
+     * Update the specified resource in storage.
+     */
+    public function update(Request $request, Tipocita $tipocita)
+    {
+        $data = $request->validate([
+            'nombre' => ['required', 'string', 'max:255'],
+        ]);
+
+        $tipocita->update($data);
+
+        return redirect()
+            ->route('tipocitas.index')
+            ->with('success', 'Tipo de cita actualizada correctamente.');
+    }
+
+    /**
+     * Remove the specified resource from storage.
+     */
+    public function destroy(Tipocita $tipocita)
+    {
+        $tipocita->delete();
+
+        return redirect()
+            ->route('tipocitas.index')
+            ->with('success', 'Tipo de cita eliminada correctamente.');
+    }
+}

--- a/resources/views/tipocitas/create.blade.php
+++ b/resources/views/tipocitas/create.blade.php
@@ -1,0 +1,21 @@
+@extends('layouts.vertical', ['subtitle' => 'Nuevo tipo de cita'])
+
+@section('content')
+<div class="container">
+    <h1 class="h3 mb-4">Crear tipo de cita</h1>
+
+    <div class="card">
+        <div class="card-body">
+            <form method="POST" action="{{ route('tipocitas.store') }}">
+                @csrf
+                @include('tipocitas.form')
+
+                <div class="d-flex justify-content-between">
+                    <a href="{{ route('tipocitas.index') }}" class="btn btn-outline-secondary">Cancelar</a>
+                    <button type="submit" class="btn btn-primary">Guardar</button>
+                </div>
+            </form>
+        </div>
+    </div>
+</div>
+@endsection

--- a/resources/views/tipocitas/edit.blade.php
+++ b/resources/views/tipocitas/edit.blade.php
@@ -1,0 +1,22 @@
+@extends('layouts.vertical', ['subtitle' => 'Editar tipo de cita'])
+
+@section('content')
+<div class="container">
+    <h1 class="h3 mb-4">Editar tipo de cita</h1>
+
+    <div class="card">
+        <div class="card-body">
+            <form method="POST" action="{{ route('tipocitas.update', $tipocita) }}">
+                @csrf
+                @method('PUT')
+                @include('tipocitas.form')
+
+                <div class="d-flex justify-content-between">
+                    <a href="{{ route('tipocitas.index') }}" class="btn btn-outline-secondary">Cancelar</a>
+                    <button type="submit" class="btn btn-primary">Actualizar</button>
+                </div>
+            </form>
+        </div>
+    </div>
+</div>
+@endsection

--- a/resources/views/tipocitas/form.blade.php
+++ b/resources/views/tipocitas/form.blade.php
@@ -1,0 +1,14 @@
+<div class="mb-3">
+    <label for="nombre" class="form-label">Nombre</label>
+    <input
+        type="text"
+        name="nombre"
+        id="nombre"
+        class="form-control @error('nombre') is-invalid @enderror"
+        value="{{ old('nombre', $tipocita->nombre ?? '') }}"
+        required
+    >
+    @error('nombre')
+        <div class="invalid-feedback">{{ $message }}</div>
+    @enderror
+</div>

--- a/resources/views/tipocitas/index.blade.php
+++ b/resources/views/tipocitas/index.blade.php
@@ -1,0 +1,53 @@
+@extends('layouts.vertical', ['subtitle' => 'Tipos de cita'])
+
+@section('content')
+<div class="container">
+    <div class="d-flex justify-content-between align-items-center mb-4">
+        <h1 class="h3 mb-0">Tipos de cita</h1>
+        <a href="{{ route('tipocitas.create') }}" class="btn btn-primary">Nuevo tipo de cita</a>
+    </div>
+
+    @if(session('success'))
+        <div class="alert alert-success">{{ session('success') }}</div>
+    @endif
+
+    <div class="card">
+        <div class="table-responsive">
+            <table class="table table-striped mb-0">
+                <thead>
+                    <tr>
+                        <th scope="col">ID</th>
+                        <th scope="col">Nombre</th>
+                        <th scope="col" class="text-end">Acciones</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    @forelse($tipocitas as $tipocita)
+                        <tr>
+                            <td>{{ $tipocita->id }}</td>
+                            <td>{{ $tipocita->nombre }}</td>
+                            <td class="text-end">
+                                <a href="{{ route('tipocitas.edit', $tipocita) }}" class="btn btn-sm btn-secondary">Editar</a>
+                                <form action="{{ route('tipocitas.destroy', $tipocita) }}" method="POST" class="d-inline">
+                                    @csrf
+                                    @method('DELETE')
+                                    <button type="submit" class="btn btn-sm btn-danger" onclick="return confirm('¿Eliminar este tipo de cita?')">
+                                        Eliminar
+                                    </button>
+                                </form>
+                            </td>
+                        </tr>
+                    @empty
+                        <tr>
+                            <td colspan="3" class="text-center">No hay tipos de cita registrados.</td>
+                        </tr>
+                    @endforelse
+                </tbody>
+            </table>
+        </div>
+        <div class="card-footer">
+            {{ $tipocitas->links() }}
+        </div>
+    </div>
+</div>
+@endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -21,6 +21,7 @@ use App\Http\Controllers\UsuarioController;
 use App\Http\Controllers\BancoController;
 use App\Http\Controllers\ItemController;
 use App\Http\Controllers\TipoUsuarioController;
+use App\Http\Controllers\TipocitaController;
 use App\Http\Controllers\SalidaController;
 use App\Http\Controllers\ProveedorController;
 use App\Http\Controllers\Admin\DashboardController;
@@ -110,6 +111,7 @@ Route::resource('proveedores', ProveedorController::class);
 Route::resource('salidas', SalidaController::class);
 Route::get('/clientesb', [ClientesController::class, 'search'])->name('clientes.search');
 Route::resource('tipo-usuarios', TipoUsuarioController::class);
+Route::resource('tipocitas', TipocitaController::class)->except(['show']);
 Route::resource('peluquerias', PeluqueriaController::class)
      ->except(['edit','update']);
 Route::get('peluqueria/editar',     [PeluqueriaController::class, 'editOwn'])


### PR DESCRIPTION
## Summary
- add a dedicated `TipocitaController` to manage listing, creation, edition, and deletion of tipos de cita
- provide Blade views for index, create, edit, and shared form partial to support the new workflow
- register the `tipocitas` resource routes within the authenticated application area

## Testing
- `php artisan test` *(fails: missing vendor/autoload.php in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ccbc8fb2308324aa99235cf12c2b92