### PR TITLE
Allow salidas without proveedor

### DIFF
--- a/app/Http/Controllers/SalidaController.php
+++ b/app/Http/Controllers/SalidaController.php
@@ -33,6 +33,7 @@ class SalidaController extends Controller
             'valor' => $request->input('valor') === null || $request->input('valor') === ''
                 ? null
                 : (int) preg_replace('/[^\d]/', '', (string) $request->input('valor')),
+            'tercero_id' => $request->filled('tercero_id') ? $request->input('tercero_id') : null,
         ]);
 
         $data = $request->validate([
@@ -43,7 +44,7 @@ class SalidaController extends Controller
             'valor'              => 'required|integer|min:0',
             'observaciones'      => 'nullable|string',
             'responsable_id'     => 'required|exists:users,id',
-            'tercero_id'         => 'required|exists:proveedors,id',
+            'tercero_id'         => 'nullable|exists:proveedors,id',
         ]);
 
         $data['cuenta_bancaria_id'] = $data['origen'] === 'banco'
@@ -81,6 +82,7 @@ class SalidaController extends Controller
             'valor' => $request->input('valor') === null || $request->input('valor') === ''
                 ? null
                 : (int) preg_replace('/[^\d]/', '', (string) $request->input('valor')),
+            'tercero_id' => $request->filled('tercero_id') ? $request->input('tercero_id') : null,
         ]);
 
         $data = $request->validate([
@@ -91,7 +93,7 @@ class SalidaController extends Controller
             'valor'              => 'required|integer|min:0',
             'observaciones'      => 'nullable|string',
             'responsable_id'     => 'required|exists:users,id',
-            'tercero_id'         => 'required|exists:proveedors,id',
+            'tercero_id'         => 'nullable|exists:proveedors,id',
         ]);
 
         $data['cuenta_bancaria_id'] = $data['origen'] === 'banco'

--- a/resources/views/salidas/_form.blade.php
+++ b/resources/views/salidas/_form.blade.php
@@ -49,10 +49,9 @@
         id="tercero_id"
         name="tercero_id"
         class="form-select"
-        required
     >
-        <option value="" disabled {{ old('tercero_id', $editando ? $salida->tercero_id : '') === '' ? 'selected' : '' }}>
-            — Selecciona proveedor —
+        <option value="" {{ old('tercero_id', $editando ? $salida->tercero_id : '') === '' ? 'selected' : '' }}>
+            — Sin proveedor —
         </option>
         @foreach($proveedores as $proveedor)
             <option


### PR DESCRIPTION
## Summary
- allow submitting salidas without a proveedor by removing the required select constraint
- update SalidaController validation to accept nullable proveedor IDs and normalize empty values to null

## Testing
- php artisan test *(fails: vendor dependencies not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dc72a6a48c83248ff9bc1f99680e25