### PR TITLE
Add No Asistida reservation status with blue styling

### DIFF
--- a/app/Http/Controllers/ReservaController.php
+++ b/app/Http/Controllers/ReservaController.php
@@ -115,6 +115,12 @@ class ReservaController extends Controller
                           ->toIso8601String();
 						  
         $color = optional($r->entrenador)->color ?? '#6042F5';
+        $textColor = '#121212';
+
+        if ($r->estado === 'No Asistida') {
+            $color = '#0d6efd';
+            $textColor = '#ffffff';
+        }
 
         $base = [
             'id'              => $r->id,
@@ -125,7 +131,7 @@ class ReservaController extends Controller
             'duration'        => $r->duracion,
             'title'           => optional($r->cliente)->nombres . ' ' . optional($r->cliente)->apellidos,
             'borderColor'     => $color,
-            'textColor'       => '#121212',
+            'textColor'       => $textColor,
             'backgroundColor' => $color,
             'extendedProps'   => [
                 'tipo'          => $r->tipo,              // reserva | torneo | clase
@@ -173,7 +179,7 @@ public function store(Request $request)
         'start'          => 'required|date',                // "YYYY-MM-DD HH:MM"
         'duration'       => 'nullable|integer|min:1',
         'entrenador_id'  => 'required_if:type,Clase|nullable',
-        'estado'         => 'required|in:Confirmada,Pendiente,Cancelada',
+        'estado'         => 'required|in:Confirmada,Pendiente,Cancelada,No Asistida',
         'cliente_id'     => 'required_if:type,Reserva|integer|exists:clientes,id',
       
         
@@ -323,7 +329,7 @@ public function update(Request $request, Reserva $reserva)
             'type'          => ['required', Rule::in(['Reserva','Clase','Torneo'])],
             'start'         => 'required|date',
             'duration'      => 'integer|min:1',
-            'estado'        => 'required|in:Confirmada,Pendiente,Cancelada',
+            'estado'        => 'required|in:Confirmada,Pendiente,Cancelada,No Asistida',
             'cancha_id'     => 'required_if:type,Reserva,Clase|exists:canchas,id',
             'cliente_id'    => 'required_if:type,Reserva,Clase|exists:clientes,id',
             'entrenador_id' => 'required_if:type,Clase|nullable',

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -342,6 +342,13 @@ form.action                          = '/reservas/' + ev.id;
   /* ---- 2)  COMMON data: extended props ---- */
   const estado = arg.event.extendedProps.status;      // Confirmada / Pendiente…
   const time   = arg.timeText;
+  const estadoBadgeClasses = {
+    'Confirmada': ['bg-success'],
+    'Pendiente': ['bg-warning', 'text-dark'],
+    'Cancelada': ['bg-danger'],
+    'No Asistida': ['bg-primary']
+  };
+  const estadoClasses = estadoBadgeClasses[estado] || ['bg-secondary'];
 
    
 
@@ -375,8 +382,7 @@ form.action                          = '/reservas/' + ev.id;
     if (estado) {
       const badge = document.createElement('span');
       badge.classList.add('badge', 'align-self-start', 'fs-8');
-      if (estado === 'Confirmada') badge.classList.add('bg-success');
-      else                         badge.classList.add('bg-warning', 'text-dark');
+      estadoClasses.forEach(cls => badge.classList.add(cls));
       badge.innerText = estado;
       cont.appendChild(badge);
     }
@@ -403,11 +409,7 @@ form.action                          = '/reservas/' + ev.id;
   if (estado) {
     const badge = document.createElement('span');
     badge.classList.add('badge', 'ms-auto', 'position-absolute', 'top-0', 'end-0', 'me-1', 'mt-1', 'fs-8');
-    if (estado === 'Confirmada') {
-      badge.classList.add('bg-success');
-    } else {
-      badge.classList.add('bg-warning', 'text-dark');
-    }
+    estadoClasses.forEach(cls => badge.classList.add(cls));
     badge.innerText = estado;
     container.appendChild(badge);
   }

--- a/resources/views/clientes/view.blade.php
+++ b/resources/views/clientes/view.blade.php
@@ -1,6 +1,9 @@
 {{-- resources/views/clientes/show.blade.php --}}
 
 @extends('layouts.vertical', ['subtitle' => 'Perfil Cliente'])
+@php
+  use Illuminate\Support\Str;
+@endphp
 
 @section('css')
   <style>
@@ -124,9 +127,13 @@
 	.pendiente{
 		background-color: rgba(255, 193, 7, 0.35);
 	}
-	.cancelada{
-	   background-color: rgba(220, 53, 69, 0.35);
-	}
+        .cancelada{
+           background-color: rgba(220, 53, 69, 0.35);
+        }
+        .no-asistida{
+          background-color: rgba(13, 110, 253, 0.35);
+          color: #0d6efd;
+        }
 	
   </style>
 @endsection
@@ -169,6 +176,7 @@
                 <span>{{ $reserva->fecha }}</span>
                 <span>{{ $reserva->tipo ?? $reserva->type }}</span>
                 <span>{{ optional($reserva->entrenador)->nombre }}</span>
+                <span class="status {{ Str::slug($reserva->estado, '-') }}">{{ $reserva->estado }}</span>
               </li>
             @endforeach
           </ul>

--- a/resources/views/reservas/partials/reservation-modal-horario.blade.php
+++ b/resources/views/reservas/partials/reservation-modal-horario.blade.php
@@ -103,7 +103,8 @@
               <select id="reservaEstado" name="estado" class="form-select" required>
                 <option value="Pendiente">Pendiente</option>
                 <option value="Confirmada">Confirmada</option>
-				 <option value="Cancelada">Cancelada</option>
+                                 <option value="No Asistida">No Asistida</option>
+                                 <option value="Cancelada">Cancelada</option>
               </select>
             </div>
 

--- a/resources/views/reservas/partials/reservation-modal.blade.php
+++ b/resources/views/reservas/partials/reservation-modal.blade.php
@@ -53,7 +53,8 @@
               <select id="reservaEstado" name="estado" class="form-select" required>
                 <option value="Pendiente">Pendiente</option>
                 <option value="Confirmada">Confirmada</option>
-				 <option value="Cancelada">Cancelada</option>
+                <option value="No Asistida">No Asistida</option>
+                                 <option value="Cancelada">Cancelada</option>
               </select>
             </div>
 			


### PR DESCRIPTION
## Summary
- allow selecting the new "No Asistida" reservation status and expose it in the calendar event payload
- colour-code calendar badges for each status, highlighting "No Asistida" in blue for clarity
- surface reservation status badges on the client profile with dedicated styling for the new state

## Testing
- php -l app/Http/Controllers/ReservaController.php

------
https://chatgpt.com/codex/tasks/task_e_68e091842e748324a1c8326297d4d88c