### PR TITLE
Add public client booking portal with verification flow

### DIFF
--- a/app/Http/Controllers/Public/BookingController.php
+++ b/app/Http/Controllers/Public/BookingController.php
@@ -1,0 +1,349 @@
+<?php
+
+namespace App\Http\Controllers\Public;
+
+use App\Http\Controllers\Controller;
+use App\Mail\ClienteVerificationMail;
+use App\Models\Cliente;
+use App\Models\Peluqueria;
+use App\Models\Reserva;
+use App\Models\Tipocita;
+use Carbon\Carbon;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Facades\Mail;
+use Illuminate\Support\Facades\Validator;
+use Illuminate\Support\Str;
+
+class BookingController extends Controller
+{
+    public function show(Peluqueria $peluqueria)
+    {
+        $this->setTenantConnection($peluqueria);
+
+        $cliente = $this->currentClient($peluqueria);
+        $tipocitas = Tipocita::orderBy('nombre')->get();
+        $proximasReservas = collect();
+
+        if ($cliente) {
+            $proximasReservas = Reserva::where('cliente_id', $cliente->id)
+                ->orderBy('fecha')
+                ->whereDate('fecha', '>=', Carbon::today())
+                ->take(5)
+                ->get();
+        }
+
+        return view('public.booking', [
+            'peluqueria' => $peluqueria,
+            'tipocitas' => $tipocitas,
+            'cliente' => $cliente,
+            'proximasReservas' => $proximasReservas,
+        ]);
+    }
+
+    public function register(Request $request, Peluqueria $peluqueria)
+    {
+        $this->setTenantConnection($peluqueria);
+
+        $validator = Validator::make($request->all(), [
+            'nombres' => ['required', 'string', 'max:200'],
+            'apellidos' => ['nullable', 'string', 'max:200'],
+            'correo' => ['required', 'email', 'max:200'],
+            'whatsapp' => ['nullable', 'string', 'max:200'],
+            'password' => ['required', 'string', 'min:8', 'confirmed'],
+        ], [
+            'password.confirmed' => 'La confirmación de la contraseña no coincide.',
+        ]);
+
+        if ($validator->fails()) {
+            return back()->withErrors($validator, 'register')->withInput();
+        }
+
+        $data = $validator->validated();
+        $correo = strtolower($data['correo']);
+
+        if (Cliente::where('correo', $correo)->exists()) {
+            return back()
+                ->withErrors(['correo' => 'Este correo ya está registrado.'], 'register')
+                ->withInput();
+        }
+
+        $cliente = new Cliente([
+            'nombres' => $data['nombres'],
+            'apellidos' => $data['apellidos'] ?? null,
+            'correo' => $correo,
+            'whatsapp' => $data['whatsapp'] ?? null,
+        ]);
+
+        $cliente->password = Hash::make($data['password']);
+        $cliente->verification_token = Str::random(64);
+        $cliente->save();
+
+        $verifyUrl = $this->verificationUrl($peluqueria, $cliente);
+        Mail::to($cliente->correo)->send(new ClienteVerificationMail($peluqueria, $cliente, $verifyUrl));
+
+        $request->session()->forget($this->sessionKey($peluqueria));
+        $request->session()->put($this->pendingKey($peluqueria), $cliente->correo);
+
+        return redirect()
+            ->route('public.booking.show', $peluqueria)
+            ->with('status', 'Registro exitoso. Revisa tu correo para verificar tu cuenta.');
+    }
+
+    public function login(Request $request, Peluqueria $peluqueria)
+    {
+        $this->setTenantConnection($peluqueria);
+
+        $validator = Validator::make($request->all(), [
+            'correo' => ['required', 'email'],
+            'password' => ['required', 'string'],
+        ]);
+
+        if ($validator->fails()) {
+            return back()->withErrors($validator, 'login')->withInput();
+        }
+
+        $data = $validator->validated();
+        $correo = strtolower($data['correo']);
+
+        $cliente = Cliente::where('correo', $correo)->first();
+
+        if (! $cliente || empty($cliente->password) || ! Hash::check($data['password'], $cliente->password)) {
+            return back()
+                ->withErrors(['correo' => 'Credenciales inválidas.'], 'login')
+                ->withInput($request->only('correo'));
+        }
+
+        if (! $cliente->email_verified_at) {
+            return back()
+                ->withErrors(['correo' => 'Debes verificar tu correo antes de agendar.'], 'login')
+                ->withInput($request->only('correo'));
+        }
+
+        $request->session()->put($this->sessionKey($peluqueria), $cliente->id);
+        $request->session()->forget($this->pendingKey($peluqueria));
+        $request->session()->regenerate();
+
+        return redirect()
+            ->route('public.booking.show', $peluqueria)
+            ->with('status', 'Bienvenido de nuevo. Ya puedes agendar tu cita.');
+    }
+
+    public function logout(Request $request, Peluqueria $peluqueria)
+    {
+        $request->session()->forget($this->sessionKey($peluqueria));
+        $request->session()->forget($this->pendingKey($peluqueria));
+        $request->session()->regenerateToken();
+
+        return redirect()->route('public.booking.show', $peluqueria)
+            ->with('status', 'Has cerrado sesión correctamente.');
+    }
+
+    public function schedule(Request $request, Peluqueria $peluqueria)
+    {
+        $this->setTenantConnection($peluqueria);
+
+        $cliente = $this->currentClient($peluqueria);
+
+        if (! $cliente) {
+            return redirect()
+                ->route('public.booking.show', $peluqueria)
+                ->withErrors(['general' => 'Debes iniciar sesión para agendar.'], 'appointment');
+        }
+
+        if (! $cliente->email_verified_at) {
+            return redirect()
+                ->route('public.booking.show', $peluqueria)
+                ->withErrors(['general' => 'Verifica tu correo para poder agendar.'], 'appointment');
+        }
+
+        $validator = Validator::make($request->all(), [
+            'fecha' => ['required', 'date_format:Y-m-d'],
+            'hora' => ['required', 'date_format:H:i'],
+            'duracion' => ['required', 'integer', 'min:15', 'max:240'],
+            'tipocita_id' => ['nullable', 'integer', 'exists:tipocita,id'],
+            'nota_cliente' => ['nullable', 'string', 'max:1000'],
+        ], [
+            'tipocita_id.exists' => 'El tipo de cita seleccionado no es válido.',
+        ]);
+
+        if ($validator->fails()) {
+            return redirect()
+                ->route('public.booking.show', $peluqueria)
+                ->withErrors($validator, 'appointment')
+                ->withInput();
+        }
+
+        $data = $validator->validated();
+
+        $inicio = Carbon::createFromFormat('Y-m-d H:i', $data['fecha'] . ' ' . $data['hora']);
+        if ($inicio->isPast()) {
+            return redirect()
+                ->route('public.booking.show', $peluqueria)
+                ->withErrors(['fecha' => 'No puedes agendar en una fecha pasada.'], 'appointment')
+                ->withInput();
+        }
+
+        $duracion = (int) $data['duracion'];
+        $fin = (clone $inicio)->addMinutes($duracion);
+
+        $conflicto = Reserva::where('estado', '<>', 'Cancelada')
+            ->where(function ($query) use ($inicio, $fin) {
+                $query->whereBetween('fecha', [$inicio, $fin->copy()->subSecond()])
+                    ->orWhere(function ($sub) use ($inicio, $fin) {
+                        $sub->where('fecha', '<=', $inicio)
+                            ->whereRaw('DATE_ADD(fecha, INTERVAL duracion MINUTE) > ?', [$inicio->format('Y-m-d H:i:s')]);
+                    });
+            })
+            ->exists();
+
+        if ($conflicto) {
+            return redirect()
+                ->route('public.booking.show', $peluqueria)
+                ->withErrors(['fecha' => 'El horario seleccionado ya no está disponible.'], 'appointment')
+                ->withInput();
+        }
+
+        $tipoCita = null;
+        if (! empty($data['tipocita_id'])) {
+            $tipoCita = Tipocita::find($data['tipocita_id']);
+        }
+
+        Reserva::create([
+            'fecha' => $inicio,
+            'duracion' => $duracion,
+            'cliente_id' => $cliente->id,
+            'estado' => 'Pendiente',
+            'tipo' => $tipoCita?->nombre ?? 'Reserva',
+            'type' => 'Reserva',
+            'nota_cliente' => $data['nota_cliente'] ?? null,
+        ]);
+
+        return redirect()
+            ->route('public.booking.show', $peluqueria)
+            ->with('status', 'Tu solicitud fue enviada. Te confirmaremos por correo.');
+    }
+
+    public function verify(Request $request, Peluqueria $peluqueria)
+    {
+        $this->setTenantConnection($peluqueria);
+
+        $token = $request->query('token');
+        $correo = strtolower((string) $request->query('email'));
+
+        if (! $token || ! $correo) {
+            return redirect()
+                ->route('public.booking.show', $peluqueria)
+                ->with('error', 'El enlace de verificación no es válido o ha expirado.');
+        }
+
+        $cliente = Cliente::where('correo', $correo)
+            ->where('verification_token', $token)
+            ->first();
+
+        if (! $cliente) {
+            return redirect()
+                ->route('public.booking.show', $peluqueria)
+                ->with('error', 'El enlace de verificación no es válido o ha expirado.');
+        }
+
+        $cliente->markEmailAsVerified();
+
+        $request->session()->put($this->sessionKey($peluqueria), $cliente->id);
+        $request->session()->forget($this->pendingKey($peluqueria));
+        $request->session()->regenerate();
+
+        return redirect()
+            ->route('public.booking.show', $peluqueria)
+            ->with('status', 'Correo verificado correctamente. Ya puedes agendar tu cita.');
+    }
+
+    public function availability(Request $request, Peluqueria $peluqueria)
+    {
+        $this->setTenantConnection($peluqueria);
+
+        $date = $request->query('date');
+        if (! $date) {
+            return response()->json(['error' => 'Debes indicar la fecha.'], 422);
+        }
+
+        try {
+            $inicioJornada = Carbon::parse($date . ' 08:00:00');
+            $finJornada = Carbon::parse($date . ' 20:00:00');
+            $intervalo = 30;
+
+            $reservas = Reserva::whereDate('fecha', $date)
+                ->where('estado', '<>', 'Cancelada')
+                ->get(['fecha', 'duracion']);
+
+            $ocupados = [];
+            foreach ($reservas as $reserva) {
+                $inicio = Carbon::parse($reserva->fecha);
+                $fin = (clone $inicio)->addMinutes((int) ($reserva->duracion ?? 0));
+                $ocupados[] = [$inicio, $fin];
+            }
+
+            $slots = [];
+            for ($cursor = $inicioJornada->copy(); $cursor->lt($finJornada); $cursor->addMinutes($intervalo)) {
+                $finSlot = $cursor->copy()->addMinutes($intervalo);
+                $choca = false;
+                foreach ($ocupados as [$ocInicio, $ocFin]) {
+                    if ($cursor < $ocFin && $finSlot > $ocInicio) {
+                        $choca = true;
+                        break;
+                    }
+                }
+
+                if (! $choca) {
+                    $slots[] = $cursor->format('H:i');
+                }
+            }
+
+            return response()->json([
+                'slots' => $slots,
+                'inicio' => $inicioJornada->format('H:i'),
+                'fin' => $finJornada->format('H:i'),
+            ]);
+        } catch (\Throwable $exception) {
+            return response()->json(['error' => 'No se pudo calcular la disponibilidad.'], 500);
+        }
+    }
+
+    private function setTenantConnection(Peluqueria $peluqueria): void
+    {
+        config(['database.connections.tenant.database' => $peluqueria->db]);
+        DB::purge('tenant');
+        DB::reconnect('tenant');
+        DB::setDefaultConnection('tenant');
+    }
+
+    private function currentClient(Peluqueria $peluqueria): ?Cliente
+    {
+        $id = session($this->sessionKey($peluqueria));
+        if (! $id) {
+            return null;
+        }
+
+        return Cliente::find($id);
+    }
+
+    private function verificationUrl(Peluqueria $peluqueria, Cliente $cliente): string
+    {
+        return route('public.booking.verify', [
+            'peluqueria' => $peluqueria,
+            'token' => $cliente->verification_token,
+            'email' => $cliente->correo,
+        ]);
+    }
+
+    private function sessionKey(Peluqueria $peluqueria): string
+    {
+        return 'public_cliente_' . $peluqueria->id;
+    }
+
+    private function pendingKey(Peluqueria $peluqueria): string
+    {
+        return 'public_cliente_pending_' . $peluqueria->id;
+    }
+}

--- a/app/Mail/ClienteVerificationMail.php
+++ b/app/Mail/ClienteVerificationMail.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Mail;
+
+use App\Models\Cliente;
+use App\Models\Peluqueria;
+use Illuminate\Bus\Queueable;
+use Illuminate\Mail\Mailable;
+use Illuminate\Queue\SerializesModels;
+
+class ClienteVerificationMail extends Mailable
+{
+    use Queueable, SerializesModels;
+
+    public function __construct(
+        public Peluqueria $peluqueria,
+        public Cliente $cliente,
+        public string $verificationUrl
+    ) {
+    }
+
+    public function build(): self
+    {
+        return $this->subject('Confirma tu correo en ' . $this->peluqueria->nombre)
+            ->markdown('emails.clientes.verify')
+            ->with([
+                'peluqueria' => $this->peluqueria,
+                'cliente' => $this->cliente,
+                'verificationUrl' => $this->verificationUrl,
+            ]);
+    }
+}

--- a/app/Models/Cliente.php
+++ b/app/Models/Cliente.php
@@ -2,7 +2,7 @@
 
 namespace App\Models;
 
-use Illuminate\Database\Eloquent\Model;
+use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany; 
 
 use Illuminate\Notifications\Notifiable;   
@@ -12,9 +12,9 @@ use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\DB;
   
 
-class Cliente extends Model
+class Cliente extends Authenticatable
 {
-	   protected $connection = 'tenant';
+           protected $connection = 'tenant';
 	   
 	   public function resolveRouteBinding($value, $field = null)
     {
@@ -50,7 +50,24 @@ class Cliente extends Model
   'foto',
 ];
 
- use Notifiable; 
+    use Notifiable;
+
+    protected $hidden = [
+        'password',
+        'remember_token',
+        'verification_token',
+    ];
+
+    protected $casts = [
+        'email_verified_at' => 'datetime',
+    ];
+
+    public function markEmailAsVerified(): void
+    {
+        $this->email_verified_at = now();
+        $this->verification_token = null;
+        $this->save();
+    }
 
 
     public function pais()

--- a/app/Models/Peluqueria.php
+++ b/app/Models/Peluqueria.php
@@ -3,14 +3,50 @@
 namespace App\Models;
 
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Str;
 
 class Peluqueria extends Model
 {
-	 protected $connection = 'mysql';
-	 
+    protected $connection = 'mysql';
+
     protected $fillable = [
         'nombre', 'pos', 'cuentaCobro', 'electronica',
         'terminos', 'color', 'msj_recordatorio', 'msj_bienvenida', 'msj_finalizado', 'msj_reserva_confirmada',
-        'nit', 'direccion', 'municipio', 'db'
+        'nit', 'direccion', 'municipio', 'db', 'slug'
     ];
+
+    public function getRouteKeyName(): string
+    {
+        return 'slug';
+    }
+
+    protected static function boot()
+    {
+        parent::boot();
+
+        static::creating(function (Peluqueria $peluqueria) {
+            if (empty($peluqueria->slug)) {
+                $peluqueria->slug = static::generateUniqueSlug($peluqueria->nombre);
+            }
+        });
+
+        static::updating(function (Peluqueria $peluqueria) {
+            if ($peluqueria->isDirty('nombre') && empty($peluqueria->getOriginal('slug')) && empty($peluqueria->slug)) {
+                $peluqueria->slug = static::generateUniqueSlug($peluqueria->nombre);
+            }
+        });
+    }
+
+    protected static function generateUniqueSlug(?string $nombre): string
+    {
+        $baseSlug = Str::slug($nombre ?? 'peluqueria');
+        $slug = $baseSlug;
+        $counter = 1;
+
+        while (static::where('slug', $slug)->exists()) {
+            $slug = $baseSlug . '-' . $counter++;
+        }
+
+        return $slug;
+    }
 }

--- a/app/Models/Reserva.php
+++ b/app/Models/Reserva.php
@@ -33,14 +33,15 @@ class Reserva extends Model
     'end',
     'type',
     'cliente_id',
-	'entrenador_id',
+        'entrenador_id',
     'cancha_id',
     'estado',
-	'duracion',
-	'tipo',
-	'repeat_enabled',
-	'repeat_until',
-	
+        'duracion',
+        'tipo',
+        'nota_cliente',
+        'repeat_enabled',
+        'repeat_until',
+
     // …
 ];
 

--- a/database/migrations/2025_08_20_000001_add_slug_to_peluquerias_table.php
+++ b/database/migrations/2025_08_20_000001_add_slug_to_peluquerias_table.php
@@ -1,0 +1,49 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('peluquerias', function (Blueprint $table) {
+            if (! Schema::hasColumn('peluquerias', 'slug')) {
+                $table->string('slug')->nullable()->unique()->after('nombre');
+            }
+        });
+
+        $peluquerias = DB::table('peluquerias')->select('id', 'nombre', 'slug')->get();
+
+        foreach ($peluquerias as $peluqueria) {
+            if (! empty($peluqueria->slug)) {
+                continue;
+            }
+
+            $baseSlug = Str::slug($peluqueria->nombre ?: 'peluqueria-' . $peluqueria->id);
+            $slug = $baseSlug;
+            $counter = 1;
+
+            while (DB::table('peluquerias')->where('slug', $slug)->exists()) {
+                $slug = $baseSlug . '-' . $counter++;
+            }
+
+            DB::table('peluquerias')->where('id', $peluqueria->id)->update([
+                'slug' => $slug,
+            ]);
+        }
+    }
+
+    public function down(): void
+    {
+        Schema::table('peluquerias', function (Blueprint $table) {
+            if (Schema::hasColumn('peluquerias', 'slug')) {
+                $table->dropUnique('peluquerias_slug_unique');
+                $table->dropColumn('slug');
+            }
+        });
+    }
+};

--- a/database/migrations/tenant/2025_08_20_000002_add_auth_columns_to_clientes_table.php
+++ b/database/migrations/tenant/2025_08_20_000002_add_auth_columns_to_clientes_table.php
@@ -1,0 +1,47 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('clientes', function (Blueprint $table) {
+            if (! Schema::hasColumn('clientes', 'password')) {
+                $table->string('password')->nullable()->after('correo');
+            }
+
+            if (! Schema::hasColumn('clientes', 'email_verified_at')) {
+                $table->timestamp('email_verified_at')->nullable()->after('password');
+            }
+
+            if (! Schema::hasColumn('clientes', 'verification_token')) {
+                $table->string('verification_token', 80)->nullable()->after('email_verified_at');
+            }
+
+            if (! Schema::hasColumn('clientes', 'remember_token')) {
+                $table->rememberToken()->after('verification_token');
+            }
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('clientes', function (Blueprint $table) {
+            if (Schema::hasColumn('clientes', 'remember_token')) {
+                $table->dropColumn('remember_token');
+            }
+            if (Schema::hasColumn('clientes', 'verification_token')) {
+                $table->dropColumn('verification_token');
+            }
+            if (Schema::hasColumn('clientes', 'email_verified_at')) {
+                $table->dropColumn('email_verified_at');
+            }
+            if (Schema::hasColumn('clientes', 'password')) {
+                $table->dropColumn('password');
+            }
+        });
+    }
+};

--- a/database/migrations/tenant/2025_08_20_000003_add_nota_cliente_to_reservas_table.php
+++ b/database/migrations/tenant/2025_08_20_000003_add_nota_cliente_to_reservas_table.php
@@ -1,0 +1,26 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('reservas', function (Blueprint $table) {
+            if (! Schema::hasColumn('reservas', 'nota_cliente')) {
+                $table->text('nota_cliente')->nullable()->after('tipo');
+            }
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('reservas', function (Blueprint $table) {
+            if (Schema::hasColumn('reservas', 'nota_cliente')) {
+                $table->dropColumn('nota_cliente');
+            }
+        });
+    }
+};

--- a/resources/views/emails/clientes/verify.blade.php
+++ b/resources/views/emails/clientes/verify.blade.php
@@ -1,0 +1,17 @@
+@component('mail::message')
+# ¡Hola {{ $cliente->nombres }}!
+
+Gracias por registrarte en **{{ $peluqueria->nombre }}**.
+
+Para finalizar tu registro y poder agendar tus citas, por favor confirma tu correo electrónico haciendo clic en el siguiente botón:
+
+@component('mail::button', ['url' => $verificationUrl])
+Confirmar correo
+@endcomponent
+
+Si el botón no funciona, copia y pega este enlace en tu navegador:
+{{ $verificationUrl }}
+
+Gracias,<br>
+El equipo de {{ $peluqueria->nombre }}
+@endcomponent

--- a/resources/views/public/booking.blade.php
+++ b/resources/views/public/booking.blade.php
@@ -1,0 +1,316 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Agenda tu cita - {{ $peluqueria->nombre }}</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
+    <style>
+        body {
+            font-family: 'Inter', sans-serif;
+            background: #f8f9fb;
+            color: #1f2933;
+        }
+        .hero {
+            background: linear-gradient(135deg, {{ $peluqueria->color ?? '#6c5ce7' }} 0%, #1f2933 100%);
+            color: #fff;
+            border-radius: 24px;
+            padding: 2.5rem;
+        }
+        .card-shadow {
+            box-shadow: 0 25px 50px -12px rgba(15, 23, 42, 0.15);
+            border: none;
+            border-radius: 18px;
+        }
+        .form-label {
+            font-weight: 600;
+        }
+        .btn-primary {
+            background-color: {{ $peluqueria->color ?? '#6c5ce7' }};
+            border-color: {{ $peluqueria->color ?? '#6c5ce7' }};
+        }
+        .btn-primary:hover {
+            filter: brightness(0.92);
+        }
+        .nav-pills .nav-link.active {
+            background-color: rgba(15, 23, 42, 0.08);
+            color: #1f2933;
+        }
+        .timeline-item {
+            position: relative;
+            padding-left: 1.75rem;
+            margin-bottom: 1.5rem;
+        }
+        .timeline-item::before {
+            content: '';
+            position: absolute;
+            left: 0.6rem;
+            top: 0.2rem;
+            width: 10px;
+            height: 10px;
+            background: {{ $peluqueria->color ?? '#6c5ce7' }};
+            border-radius: 50%;
+        }
+        .timeline-item::after {
+            content: '';
+            position: absolute;
+            left: 1rem;
+            top: 1.2rem;
+            bottom: -1.2rem;
+            width: 2px;
+            background: rgba(15, 23, 42, 0.1);
+        }
+        .timeline-item:last-child::after {
+            display: none;
+        }
+    </style>
+</head>
+<body>
+<div class="container py-5">
+    <div class="hero mb-5">
+        <h1 class="fw-bold mb-3">Reserva tu próximo servicio en {{ $peluqueria->nombre }}</h1>
+        <p class="lead mb-0">Crea tu cuenta, verifica tu correo e ingresa cuando quieras para agendar la cita que necesitas.</p>
+    </div>
+
+    @if (session('status'))
+        <div class="alert alert-success alert-dismissible fade show card-shadow" role="alert">
+            {{ session('status') }}
+            <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Cerrar"></button>
+        </div>
+    @endif
+    @if (session('error'))
+        <div class="alert alert-danger alert-dismissible fade show card-shadow" role="alert">
+            {{ session('error') }}
+            <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Cerrar"></button>
+        </div>
+    @endif
+
+    @php
+        $pendingVerification = session('public_cliente_pending_' . $peluqueria->id);
+        $appointmentErrors = $errors->appointment ?? null;
+    @endphp
+
+    <div class="row g-4">
+        <div class="col-lg-6">
+            <div class="card card-shadow h-100">
+                <div class="card-body p-4">
+                    <ul class="nav nav-pills nav-fill mb-4" id="authTabs" role="tablist">
+                        <li class="nav-item" role="presentation">
+                            <button class="nav-link active" id="register-tab" data-bs-toggle="pill" data-bs-target="#register" type="button" role="tab" aria-controls="register" aria-selected="true">Registrarme</button>
+                        </li>
+                        <li class="nav-item" role="presentation">
+                            <button class="nav-link" id="login-tab" data-bs-toggle="pill" data-bs-target="#login" type="button" role="tab" aria-controls="login" aria-selected="false">Iniciar sesión</button>
+                        </li>
+                    </ul>
+                    <div class="tab-content" id="authTabsContent">
+                        <div class="tab-pane fade show active" id="register" role="tabpanel" aria-labelledby="register-tab">
+                            <form method="POST" action="{{ route('public.booking.register', $peluqueria) }}">
+                                @csrf
+                                <div class="mb-3">
+                                    <label class="form-label" for="register-nombres">Nombre</label>
+                                    <input type="text" class="form-control @error('nombres', 'register') is-invalid @enderror" id="register-nombres" name="nombres" value="{{ old('nombres') }}" required>
+                                    @error('nombres', 'register')
+                                        <div class="invalid-feedback">{{ $message }}</div>
+                                    @enderror
+                                </div>
+                                <div class="mb-3">
+                                    <label class="form-label" for="register-apellidos">Apellidos</label>
+                                    <input type="text" class="form-control @error('apellidos', 'register') is-invalid @enderror" id="register-apellidos" name="apellidos" value="{{ old('apellidos') }}">
+                                    @error('apellidos', 'register')
+                                        <div class="invalid-feedback">{{ $message }}</div>
+                                    @enderror
+                                </div>
+                                <div class="mb-3">
+                                    <label class="form-label" for="register-correo">Correo electrónico</label>
+                                    <input type="email" class="form-control @error('correo', 'register') is-invalid @enderror" id="register-correo" name="correo" value="{{ old('correo') }}" required>
+                                    @error('correo', 'register')
+                                        <div class="invalid-feedback">{{ $message }}</div>
+                                    @enderror
+                                </div>
+                                <div class="mb-3">
+                                    <label class="form-label" for="register-whatsapp">WhatsApp</label>
+                                    <input type="text" class="form-control @error('whatsapp', 'register') is-invalid @enderror" id="register-whatsapp" name="whatsapp" value="{{ old('whatsapp') }}">
+                                    @error('whatsapp', 'register')
+                                        <div class="invalid-feedback">{{ $message }}</div>
+                                    @enderror
+                                </div>
+                                <div class="mb-3">
+                                    <label class="form-label" for="register-password">Contraseña</label>
+                                    <input type="password" class="form-control @error('password', 'register') is-invalid @enderror" id="register-password" name="password" required>
+                                    @error('password', 'register')
+                                        <div class="invalid-feedback">{{ $message }}</div>
+                                    @enderror
+                                </div>
+                                <div class="mb-4">
+                                    <label class="form-label" for="register-password-confirmation">Confirmar contraseña</label>
+                                    <input type="password" class="form-control" id="register-password-confirmation" name="password_confirmation" required>
+                                </div>
+                                <button type="submit" class="btn btn-primary w-100">Crear cuenta</button>
+                            </form>
+                        </div>
+                        <div class="tab-pane fade" id="login" role="tabpanel" aria-labelledby="login-tab">
+                            <form method="POST" action="{{ route('public.booking.login', $peluqueria) }}">
+                                @csrf
+                                <div class="mb-3">
+                                    <label class="form-label" for="login-correo">Correo electrónico</label>
+                                    <input type="email" class="form-control @error('correo', 'login') is-invalid @enderror" id="login-correo" name="correo" value="{{ old('correo') }}" required>
+                                    @error('correo', 'login')
+                                        <div class="invalid-feedback">{{ $message }}</div>
+                                    @enderror
+                                </div>
+                                <div class="mb-4">
+                                    <label class="form-label" for="login-password">Contraseña</label>
+                                    <input type="password" class="form-control @error('password', 'login') is-invalid @enderror" id="login-password" name="password" required>
+                                    @error('password', 'login')
+                                        <div class="invalid-feedback">{{ $message }}</div>
+                                    @enderror
+                                </div>
+                                <button type="submit" class="btn btn-primary w-100">Ingresar</button>
+                            </form>
+                        </div>
+                    </div>
+                    @if ($pendingVerification)
+                        <div class="alert alert-warning mt-4" role="alert">
+                            Hemos enviado un enlace de verificación a <strong>{{ $pendingVerification }}</strong>. Revisa tu bandeja de entrada o correo no deseado.
+                        </div>
+                    @endif
+                </div>
+            </div>
+        </div>
+        <div class="col-lg-6">
+            <div class="card card-shadow h-100">
+                <div class="card-body p-4">
+                    <h2 class="h4 fw-bold mb-4">Agenda tu cita</h2>
+                    @if ($cliente)
+                        <div class="alert alert-info" role="alert">
+                            Hola {{ $cliente->nombres }}. @if(! $cliente->email_verified_at) Tu correo aún no está verificado. Revisa tu correo para confirmar tu cuenta. @else ¡Ya puedes solicitar tu cita! @endif
+                        </div>
+                        <form method="POST" action="{{ route('public.booking.appointment', $peluqueria) }}" class="mb-4">
+                            @csrf
+                            <div class="row g-3">
+                                <div class="col-md-6">
+                                    <label class="form-label" for="appointment-date">Fecha</label>
+                                    <input type="date" class="form-control @if($appointmentErrors?->has('fecha')) is-invalid @endif" id="appointment-date" name="fecha" value="{{ old('fecha') ?? now()->format('Y-m-d') }}" required>
+                                    @if($appointmentErrors?->has('fecha'))
+                                        <div class="invalid-feedback">{{ $appointmentErrors->first('fecha') }}</div>
+                                    @endif
+                                </div>
+                                <div class="col-md-6">
+                                    <label class="form-label" for="appointment-time">Hora</label>
+                                    <select class="form-select @if($appointmentErrors?->has('hora')) is-invalid @endif" id="appointment-time" name="hora" required>
+                                        <option value="">Selecciona un horario</option>
+                                    </select>
+                                    @if($appointmentErrors?->has('hora'))
+                                        <div class="invalid-feedback">{{ $appointmentErrors->first('hora') }}</div>
+                                    @endif
+                                </div>
+                                <div class="col-md-6">
+                                    <label class="form-label" for="appointment-duration">Duración (minutos)</label>
+                                    <input type="number" class="form-control @if($appointmentErrors?->has('duracion')) is-invalid @endif" id="appointment-duration" name="duracion" min="15" max="240" step="15" value="{{ old('duracion', 60) }}" required>
+                                    @if($appointmentErrors?->has('duracion'))
+                                        <div class="invalid-feedback">{{ $appointmentErrors->first('duracion') }}</div>
+                                    @endif
+                                </div>
+                                <div class="col-md-6">
+                                    <label class="form-label" for="appointment-tipocita">Servicio</label>
+                                    <select class="form-select @if($appointmentErrors?->has('tipocita_id')) is-invalid @endif" id="appointment-tipocita" name="tipocita_id">
+                                        <option value="">Selecciona una opción</option>
+                                        @foreach($tipocitas as $tipo)
+                                            <option value="{{ $tipo->id }}" @selected(old('tipocita_id') == $tipo->id)>{{ $tipo->nombre }}</option>
+                                        @endforeach
+                                    </select>
+                                    @if($appointmentErrors?->has('tipocita_id'))
+                                        <div class="invalid-feedback">{{ $appointmentErrors->first('tipocita_id') }}</div>
+                                    @endif
+                                </div>
+                                <div class="col-12">
+                                    <label class="form-label" for="appointment-note">Notas adicionales</label>
+                                    <textarea class="form-control @if($appointmentErrors?->has('nota_cliente')) is-invalid @endif" id="appointment-note" name="nota_cliente" rows="3" placeholder="Cuéntanos detalles que debamos saber">{{ old('nota_cliente') }}</textarea>
+                                    @if($appointmentErrors?->has('nota_cliente'))
+                                        <div class="invalid-feedback">{{ $appointmentErrors->first('nota_cliente') }}</div>
+                                    @endif
+                                </div>
+                            </div>
+                            <button type="submit" class="btn btn-primary mt-4 w-100" @if(! $cliente->email_verified_at) disabled @endif>Solicitar cita</button>
+                        </form>
+                        <form method="POST" action="{{ route('public.booking.logout', $peluqueria) }}">
+                            @csrf
+                            <button type="submit" class="btn btn-outline-danger w-100">Cerrar sesión</button>
+                        </form>
+                    @else
+                        <p class="text-muted">Regístrate o inicia sesión para agendar una cita. Si ya hiciste tu registro recuerda verificar el enlace que enviamos a tu correo.</p>
+                    @endif
+                </div>
+            </div>
+        </div>
+    </div>
+
+    @if($cliente && $proximasReservas->isNotEmpty())
+        <div class="card card-shadow mt-4">
+            <div class="card-body p-4">
+                <h2 class="h5 fw-bold mb-4">Tus próximas solicitudes</h2>
+                @foreach($proximasReservas as $reserva)
+                    <div class="timeline-item">
+                        <h3 class="h6 mb-1">{{ $reserva->tipo ?? 'Reserva' }} · {{ \Carbon\Carbon::parse($reserva->fecha)->format('d/m/Y H:i') }}</h3>
+                        <p class="mb-1 text-muted">Estado: <strong>{{ $reserva->estado }}</strong> · Duración: {{ $reserva->duracion }} minutos</p>
+                        @if($reserva->nota_cliente)
+                            <p class="mb-0 small">Nota: {{ $reserva->nota_cliente }}</p>
+                        @endif
+                    </div>
+                @endforeach
+            </div>
+        </div>
+    @endif
+</div>
+
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
+<script>
+    document.addEventListener('DOMContentLoaded', () => {
+        const dateInput = document.getElementById('appointment-date');
+        const timeSelect = document.getElementById('appointment-time');
+        const storedTime = @json(old('hora'));
+
+        const fetchSlots = () => {
+            if (!dateInput || !timeSelect || !dateInput.value) {
+                return;
+            }
+
+            timeSelect.innerHTML = '<option value="">Cargando horarios...</option>';
+
+            fetch('{{ route('public.booking.availability', $peluqueria) }}?date=' + dateInput.value)
+                .then(response => response.json())
+                .then(data => {
+                    timeSelect.innerHTML = '<option value="">Selecciona un horario</option>';
+                    if (data.slots && data.slots.length) {
+                        data.slots.forEach(slot => {
+                            const option = document.createElement('option');
+                            option.value = slot;
+                            option.textContent = slot;
+                            if (storedTime && storedTime === slot) {
+                                option.selected = true;
+                            }
+                            timeSelect.appendChild(option);
+                        });
+                    } else {
+                        const option = document.createElement('option');
+                        option.value = '';
+                        option.textContent = 'Sin horarios disponibles';
+                        timeSelect.appendChild(option);
+                    }
+                })
+                .catch(() => {
+                    timeSelect.innerHTML = '<option value="">No se pudo cargar la disponibilidad</option>';
+                });
+        };
+
+        if (dateInput) {
+            dateInput.addEventListener('change', fetchSlots);
+            fetchSlots();
+        }
+    });
+</script>
+</body>
+</html>

--- a/resources/views/reservas/pending.blade.php
+++ b/resources/views/reservas/pending.blade.php
@@ -1,0 +1,91 @@
+@extends('layouts.vertical', ['subtitle' => 'Reservas pendientes'])
+
+@section('content')
+<div class="row">
+    <div class="col-12">
+        <div class="card">
+            <div class="card-header d-flex justify-content-between align-items-center">
+                <div>
+                    <h5 class="mb-1">Solicitudes pendientes de confirmación</h5>
+                    <p class="mb-0 text-muted">Revisa y confirma las citas solicitadas desde el portal público.</p>
+                </div>
+                <a href="{{ route('reservas.calendar') }}" class="btn btn-outline-primary">Ver calendario</a>
+            </div>
+            <div class="card-body">
+                @if (session('success'))
+                    <div class="alert alert-success">{{ session('success') }}</div>
+                @endif
+                @if (session('error'))
+                    <div class="alert alert-danger">{{ session('error') }}</div>
+                @endif
+
+                <div class="table-responsive">
+                    <table class="table table-hover align-middle">
+                        <thead class="table-light">
+                            <tr>
+                                <th>Fecha y hora</th>
+                                <th>Cliente</th>
+                                <th>Servicio</th>
+                                <th>Duración</th>
+                                <th>Notas del cliente</th>
+                                <th>Acciones</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                        @forelse ($reservas as $reserva)
+                            <tr>
+                                <td>
+                                    <div class="fw-semibold">{{ \Carbon\Carbon::parse($reserva->fecha)->format('d/m/Y H:i') }}</div>
+                                    <span class="badge bg-warning text-dark">{{ $reserva->estado }}</span>
+                                </td>
+                                <td>
+                                    <div class="fw-semibold">{{ optional($reserva->cliente)->nombres }} {{ optional($reserva->cliente)->apellidos }}</div>
+                                    <small class="text-muted">{{ optional($reserva->cliente)->correo }}</small>
+                                </td>
+                                <td>{{ $reserva->tipo ?? 'Reserva' }}</td>
+                                <td>{{ $reserva->duracion }} min</td>
+                                <td>
+                                    @if ($reserva->nota_cliente)
+                                        <span class="text-break">{{ $reserva->nota_cliente }}</span>
+                                    @else
+                                        <span class="text-muted">Sin comentarios</span>
+                                    @endif
+                                </td>
+                                <td>
+                                    <div class="d-flex gap-2">
+                                        <form method="POST" action="{{ route('reservas.pending.confirm', $reserva) }}">
+                                            @csrf
+                                            <button type="submit" class="btn btn-success btn-sm">Confirmar</button>
+                                        </form>
+                                        <form method="POST" action="{{ route('reservas.update', $reserva) }}">
+                                            @csrf
+                                            @method('PUT')
+                                            <input type="hidden" name="type" value="{{ $reserva->type ?? 'Reserva' }}">
+                                            <input type="hidden" name="start" value="{{ $reserva->fecha }}">
+                                            <input type="hidden" name="duration" value="{{ $reserva->duracion }}">
+                                            <input type="hidden" name="estado" value="Cancelada">
+                                            <input type="hidden" name="cancha_id" value="{{ $reserva->cancha_id }}">
+                                            <input type="hidden" name="cliente_id" value="{{ $reserva->cliente_id }}">
+                                            <input type="hidden" name="entrenador_id" value="{{ $reserva->entrenador_id }}">
+                                            <button type="submit" class="btn btn-outline-danger btn-sm">Rechazar</button>
+                                        </form>
+                                    </div>
+                                </td>
+                            </tr>
+                        @empty
+                            <tr>
+                                <td colspan="6" class="text-center py-4 text-muted">No hay solicitudes pendientes por confirmar.</td>
+                            </tr>
+                        @endforelse
+                        </tbody>
+                    </table>
+                </div>
+
+                <div class="mt-3">
+                    {{ $reservas->links() }}
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+@endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -31,6 +31,7 @@ use App\Http\Controllers\Auth\LoginController;
 use App\Http\Controllers\AdministrativeReportController;
 use App\Http\Middleware\ConnectTenantDB;
 use App\Http\Controllers\Auth\AuthenticatedSessionController;
+use App\Http\Controllers\Public\BookingController;
 
 use Illuminate\Cookie\Middleware\EncryptCookies;
 use Illuminate\Cookie\Middleware\AddQueuedCookiesToResponse;
@@ -42,6 +43,21 @@ use Illuminate\Auth\Middleware\Authenticate;
 
 
 require __DIR__ . '/auth.php';
+
+Route::prefix('p/{peluqueria:slug}')
+    ->name('public.booking.')
+    ->group(function () {
+        Route::get('/', function (\App\Models\Peluqueria $peluqueria) {
+            return redirect()->route('public.booking.show', $peluqueria);
+        })->name('index');
+        Route::get('/agenda', [BookingController::class, 'show'])->name('show');
+        Route::post('/registro', [BookingController::class, 'register'])->name('register');
+        Route::post('/login', [BookingController::class, 'login'])->name('login');
+        Route::post('/logout', [BookingController::class, 'logout'])->name('logout');
+        Route::post('/citas', [BookingController::class, 'schedule'])->name('appointment');
+        Route::get('/verificar', [BookingController::class, 'verify'])->name('verify');
+        Route::get('/disponibilidad', [BookingController::class, 'availability'])->name('availability');
+    });
 
 // Rutas públicas
 Route::get('login',  [LoginController::class, 'showLoginForm'])->name('login');
@@ -112,6 +128,8 @@ Route::put('users/{user}', [UsuarioController::class,'update'])
 Route::delete('users/{user}', [UsuarioController::class,'destroy'])
      ->name('users.destroy');
 Route::get('reservas/horario', [ReservaController::class, 'horario'])->name('reservas.horario');
+Route::get('reservas/pendientes', [ReservaController::class, 'pending'])->name('reservas.pending');
+Route::post('reservas/{reserva}/confirmar-publico', [ReservaController::class, 'confirmPending'])->name('reservas.pending.confirm');
 Route::resource('proveedores', ProveedorController::class);
 Route::resource('salidas', SalidaController::class);
 Route::get('/clientesb', [ClientesController::class, 'search'])->name('clientes.search');


### PR DESCRIPTION
## Summary
- add a public booking controller, views, and mailer so salons can register clients, verify emails, and collect appointment requests
- persist client auth details and reservation notes via new tenant migrations and expose pending approval workflows in the admin panel
- restrict calendar events to confirmed bookings and generate unique slugs for salons to share branded booking URLs

## Testing
- php artisan test *(fails: missing vendor/autoload.php because Composer dependencies could not be installed in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e093f41d4c83248b8759146fc6c3cb